### PR TITLE
Changing single search query to 'Star Wars: Episode VI - Return of the J...

### DIFF
--- a/spec/omdbapi/client_spec.rb
+++ b/spec/omdbapi/client_spec.rb
@@ -106,14 +106,14 @@ describe OMDB::Client do
       end
 
       describe 'with a single search result' do
-        let(:result) { OMDB.search('The Star Wars Holiday Special') }
+        let(:result) { OMDB.search('Star Wars: Episode VI - Return of the Jedi') }
 
         it 'should return a hash of the title' do
           result.should be_instance_of Hash
         end
 
         it 'should have a title' do
-          result.title.should eq('The Star Wars Holiday Special')
+          result.title.should eq('Star Wars: Episode VI - Return of the Jedi')
         end
       end
 


### PR DESCRIPTION
I noticed that the single search was failing because there are now two movies that match the original search in the test
