### PR TITLE
add omdb api key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The complete documentation for the gem can be viewed at [rdoc.info/gems/omdbapi/
 ### Requirements
 
 * Ruby v1.9.3 or later
+* A valid OMDB API key from http://www.omdbapi.com/ (Become a Patron)
 
 ### Installing
 
@@ -39,6 +40,17 @@ $ gem install omdbapi
 ```ruby
 require 'omdbapi'
 ```
+
+## Setting the API Key:
+
+You can set the api key inline using the following code:
+
+```ruby
+OMDB.api_key = 'secret'
+```
+
+Or you can set the ENV var `OMDB_API_KEY` and it will use that automatically.
+
 ### Title
 
 You can get a movie or TV show's information in a Hash by using the title method, shown below:
@@ -117,7 +129,7 @@ This method will return a Hash of the title's properties, exactly as the title m
 The test suite is written using RSpec, and can be run by issuing the following command from the root of the repository:
 
 ```bash
-$ rspec spec
+$ OMDB_API_KEY=secret rspec spec
 ```
 
 ## Contributing

--- a/lib/omdbapi.rb
+++ b/lib/omdbapi.rb
@@ -12,8 +12,21 @@ module OMDB
     #
     # return [OMDB::Client] API Wrapper
     def client
-      @client = Client.new unless @client
+      @client = Client.new(api_key: api_key) unless @client
       @client
+    end
+
+    # Return the API key or the ENV var OMDB_API_KEY to be used in all future
+    # calls.
+    #
+    # return [String] API Key
+    def api_key
+      @api_key || ENV['OMDB_API_KEY']
+    end
+
+    # Set the API key to be used in all future calls.
+    def api_key=(val)
+      @api_key = val
     end
 
     private

--- a/lib/omdbapi/client.rb
+++ b/lib/omdbapi/client.rb
@@ -8,6 +8,10 @@ module OMDB
     include HTTParty
     base_uri OMDB::Default::API_ENDPOINT
 
+    def initialize(api_key:)
+      @api_key = api_key
+    end
+
     # Retrieves a movie or show based on its title.
     #
     # @param title [String] The title of the movie or show.
@@ -100,7 +104,7 @@ module OMDB
       # @example
       #   get '/users', { username: 'caseyscarborough' }
       def get(url, params={})
-        request = self.class.get '/', query: params
+        request = self.class.get '/', query: params.merge(apikey: @api_key)
         convert_hash_keys(request.parsed_response)
       end
   end

--- a/spec/omdbapi/client_spec.rb
+++ b/spec/omdbapi/client_spec.rb
@@ -9,6 +9,34 @@ describe OMDB::Client do
     expect(OMDB::Client.base_uri).to eq(OMDB::Default::API_ENDPOINT)
   end
 
+  describe 'api key' do
+    it "returns the instance variable if set" do
+      OMDB.api_key = 'secret'
+      expect(OMDB.api_key).to eq('secret')
+    end
+
+    it "returns the the ENV var OMDB_API_KEY if instance variable not set" do
+      OMDB.api_key = nil
+      expect(ENV).to receive(:[]).with('OMDB_API_KEY').and_return('envsecret')
+      expect(OMDB.api_key).to eq('envsecret')
+    end
+  end
+
+  describe 'client' do
+    it "instantiates a Client with the api key" do
+      OMDB.api_key = 'secret'
+      expect(OMDB::Client).to receive(:new).with(api_key: 'secret')
+      OMDB.client
+    end
+
+    it "returns the cached client if available" do
+      OMDB.api_key = 'secret'
+      OMDB.client
+      expect(OMDB::Client).not_to receive(:new)
+      OMDB.client
+    end
+  end
+
   describe 'methods' do
     describe 'title' do
       describe 'with a movie that exists' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,4 +9,5 @@ end
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/vcr'
   config.hook_into :webmock
+  config.filter_sensitive_data('<OMDB_API_KEY>') { OMDB.api_key }
 end

--- a/spec/vcr/id/existing.yml
+++ b/spec/vcr/id/existing.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://omdbapi.com/?i=tt0411008
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&i=tt0411008
     body:
       encoding: US-ASCII
       string: ''
@@ -19,22 +19,22 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Jun 2016 20:19:15 GMT
+      - Sun, 08 Oct 2017 17:12:48 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
-      - close
+      - keep-alive
       Set-Cookie:
-      - __cfduid=d8a2312fd7c55b83c70b9826c5256aa1c1465589954; expires=Sat, 10-Jun-17
-        20:19:14 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      - __cfduid=de25bef05ac7dd984645b6e7a24c899921507482768; expires=Mon, 08-Oct-18
+        17:12:48 GMT; path=/; domain=.omdbapi.com; HttpOnly
       Cache-Control:
-      - public, max-age=3600
+      - public, max-age=3508
       Expires:
-      - Fri, 10 Jun 2016 21:19:13 GMT
+      - Sun, 08 Oct 2017 18:11:17 GMT
       Last-Modified:
-      - Fri, 10 Jun 2016 20:19:13 GMT
+      - Sun, 08 Oct 2017 17:11:17 GMT
       Vary:
       - "*"
       X-Aspnet-Version:
@@ -46,7 +46,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Cf-Ray:
-      - 2b0f84622bb21e5f-SJC
+      - 3aaaba2957a31bd3-SEA
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -54,20 +54,24 @@ http_interactions:
         IlRWLTE0IiwiUmVsZWFzZWQiOiIyMiBTZXAgMjAwNCIsIlJ1bnRpbWUiOiI0
         NCBtaW4iLCJHZW5yZSI6IkFkdmVudHVyZSwgRHJhbWEsIEZhbnRhc3kiLCJE
         aXJlY3RvciI6Ik4vQSIsIldyaXRlciI6IkouSi4gQWJyYW1zLCBKZWZmcmV5
-        IExpZWJlciwgRGFtb24gTGluZGVsb2YiLCJBY3RvcnMiOiJOYXZlZW4gQW5k
-        cmV3cywgTWF0dGhldyBGb3gsIEpvcmdlIEdhcmNpYSwgSm9zaCBIb2xsb3dh
-        eSIsIlBsb3QiOiJUaGUgc3Vydml2b3JzIG9mIGEgcGxhbmUgY3Jhc2ggYXJl
-        IGZvcmNlZCB0byB3b3JrIHRvZ2V0aGVyIGluIG9yZGVyIHRvIHN1cnZpdmUg
-        b24gYSBzZWVtaW5nbHkgZGVzZXJ0ZWQgdHJvcGljYWwgaXNsYW5kLiIsIkxh
-        bmd1YWdlIjoiQXJhYmljLCBHZXJtYW4sIFJ1c3NpYW4sIFBvcnR1Z3Vlc2Us
-        IEtvcmVhbiwgTGF0aW4sIEphcGFuZXNlLCBFbmdsaXNoLCBGcmVuY2gsIFNw
-        YW5pc2giLCJDb3VudHJ5IjoiVVNBIiwiQXdhcmRzIjoiV29uIDEgR29sZGVu
-        IEdsb2JlLiBBbm90aGVyIDk4IHdpbnMgJiAzNTggbm9taW5hdGlvbnMuIiwi
-        UG9zdGVyIjoiaHR0cDovL2lhLm1lZGlhLWltZGIuY29tL2ltYWdlcy9NL01W
-        NUJNakEzTnpNeU16VTFNVjVCTWw1QmFuQm5Ya0Z0WlRjd05qYzFPRFV3TWdA
-        QC5fVjFfU1gzMDAuanBnIiwiTWV0YXNjb3JlIjoiTi9BIiwiaW1kYlJhdGlu
-        ZyI6IjguNCIsImltZGJWb3RlcyI6IjM3MCw5MjciLCJpbWRiSUQiOiJ0dDA0
-        MTEwMDgiLCJUeXBlIjoic2VyaWVzIiwiUmVzcG9uc2UiOiJUcnVlIn0=
+        IExpZWJlciwgRGFtb24gTGluZGVsb2YiLCJBY3RvcnMiOiJKb3JnZSBHYXJj
+        aWEsIEpvc2ggSG9sbG93YXksIFl1bmppbiBLaW0sIEV2YW5nZWxpbmUgTGls
+        bHkiLCJQbG90IjoiVGhlIHN1cnZpdm9ycyBvZiBhIHBsYW5lIGNyYXNoIGFy
+        ZSBmb3JjZWQgdG8gd29yayB0b2dldGhlciBpbiBvcmRlciB0byBzdXJ2aXZl
+        IG9uIGEgc2VlbWluZ2x5IGRlc2VydGVkIHRyb3BpY2FsIGlzbGFuZC4iLCJM
+        YW5ndWFnZSI6IkVuZ2xpc2gsIFBvcnR1Z3Vlc2UsIFNwYW5pc2gsIEFyYWJp
+        YywgRnJlbmNoLCBLb3JlYW4sIEdlcm1hbiwgTGF0aW4sIFJ1c3NpYW4sIEph
+        cGFuZXNlIiwiQ291bnRyeSI6IlVTQSIsIkF3YXJkcyI6IldvbiAxIEdvbGRl
+        biBHbG9iZS4gQW5vdGhlciAxMDUgd2lucyAmIDM3NiBub21pbmF0aW9ucy4i
+        LCJQb3N0ZXIiOiJodHRwczovL2ltYWdlcy1uYS5zc2wtaW1hZ2VzLWFtYXpv
+        bi5jb20vaW1hZ2VzL00vTVY1Qk1qQTNOek15TXpVMU1WNUJNbDVCYW5Cblhr
+        RnRaVGN3TmpjMU9EVXdNZ0BALl9WMV9TWDMwMC5qcGciLCJSYXRpbmdzIjpb
+        eyJTb3VyY2UiOiJJbnRlcm5ldCBNb3ZpZSBEYXRhYmFzZSIsIlZhbHVlIjoi
+        OC40LzEwIn0seyJTb3VyY2UiOiJSb3R0ZW4gVG9tYXRvZXMiLCJWYWx1ZSI6
+        IjgwJSJ9XSwiTWV0YXNjb3JlIjoiTi9BIiwiaW1kYlJhdGluZyI6IjguNCIs
+        ImltZGJWb3RlcyI6IjQxNSw2ODEiLCJpbWRiSUQiOiJ0dDA0MTEwMDgiLCJU
+        eXBlIjoic2VyaWVzIiwidG90YWxTZWFzb25zIjoiNiIsIlJlc3BvbnNlIjoi
+        VHJ1ZSJ9
     http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:19:15 GMT
+  recorded_at: Sun, 08 Oct 2017 17:12:48 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/id/nonexistent.yml
+++ b/spec/vcr/id/nonexistent.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://omdbapi.com/?i=tt1231230123
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&i=tt1231230123
     body:
       encoding: US-ASCII
       string: ''
@@ -19,22 +19,22 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Jun 2016 20:19:15 GMT
+      - Sun, 08 Oct 2017 17:12:49 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
-      - close
+      - keep-alive
       Set-Cookie:
-      - __cfduid=d5451837e6e70b52c90636d98a71ab3241465589955; expires=Sat, 10-Jun-17
-        20:19:15 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      - __cfduid=d46f3d82c5c75a8c1662598f7b8a2e6b11507482769; expires=Mon, 08-Oct-18
+        17:12:49 GMT; path=/; domain=.omdbapi.com; HttpOnly
       Cache-Control:
       - public, max-age=3600
       Expires:
-      - Fri, 10 Jun 2016 21:19:13 GMT
+      - Sun, 08 Oct 2017 18:12:49 GMT
       Last-Modified:
-      - Fri, 10 Jun 2016 20:19:13 GMT
+      - Sun, 08 Oct 2017 17:12:49 GMT
       Vary:
       - "*"
       X-Aspnet-Version:
@@ -46,10 +46,10 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Cf-Ray:
-      - 2b0f8463ca9d012b-SJC
+      - 3aaaba2a57a529e9-SEA
     body:
       encoding: ASCII-8BIT
       string: '{"Response":"False","Error":"Incorrect IMDb ID."}'
     http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:19:15 GMT
+  recorded_at: Sun, 08 Oct 2017 17:12:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/search/empty.yml
+++ b/spec/vcr/search/empty.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://omdbapi.com/?s=lsdfoweirjrpwef323423dsfkip
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&s=lsdfoweirjrpwef323423dsfkip
     body:
       encoding: US-ASCII
       string: ''
@@ -19,22 +19,22 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Jun 2016 20:19:16 GMT
+      - Sun, 08 Oct 2017 17:12:49 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
       - '47'
       Connection:
-      - close
+      - keep-alive
       Set-Cookie:
-      - __cfduid=d053f730ac1f2c9d8445dd88c7ccc311b1465589956; expires=Sat, 10-Jun-17
-        20:19:16 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      - __cfduid=d7336b0c50cd97a9a1ef1668263b1fbc11507482769; expires=Mon, 08-Oct-18
+        17:12:49 GMT; path=/; domain=.omdbapi.com; HttpOnly
       Cache-Control:
-      - public, max-age=3600
+      - public, max-age=3508
       Expires:
-      - Fri, 10 Jun 2016 21:19:14 GMT
+      - Sun, 08 Oct 2017 18:11:18 GMT
       Last-Modified:
-      - Fri, 10 Jun 2016 20:19:14 GMT
+      - Sun, 08 Oct 2017 17:11:18 GMT
       Vary:
       - "*"
       X-Aspnet-Version:
@@ -46,10 +46,10 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Cf-Ray:
-      - 2b0f846a081f071f-SJC
+      - 3aaaba2d247f7985-SEA
     body:
       encoding: UTF-8
       string: '{"Response":"False","Error":"Movie not found!"}'
     http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:19:16 GMT
+  recorded_at: Sun, 08 Oct 2017 17:12:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/search/find.yml
+++ b/spec/vcr/search/find.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://omdbapi.com/?s=Star%20Wars
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&s=Star%20Wars
     body:
       encoding: US-ASCII
       string: ''
@@ -19,22 +19,22 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Jun 2016 20:19:16 GMT
+      - Sun, 08 Oct 2017 17:12:49 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
-      - close
+      - keep-alive
       Set-Cookie:
-      - __cfduid=d01d87248178e26be678b8e037840fb441465589956; expires=Sat, 10-Jun-17
-        20:19:16 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      - __cfduid=d84ccc422a9ccd4acd7a1c1c86d9ae15b1507482769; expires=Mon, 08-Oct-18
+        17:12:49 GMT; path=/; domain=.omdbapi.com; HttpOnly
       Cache-Control:
-      - public, max-age=518
+      - public, max-age=3508
       Expires:
-      - Fri, 10 Jun 2016 20:27:52 GMT
+      - Sun, 08 Oct 2017 18:11:18 GMT
       Last-Modified:
-      - Fri, 10 Jun 2016 19:27:52 GMT
+      - Sun, 08 Oct 2017 17:11:18 GMT
       Vary:
       - "*"
       X-Aspnet-Version:
@@ -46,64 +46,71 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Cf-Ray:
-      - 2b0f846adb61287c-SJC
+      - 3aaaba2db1fe1bd3-SEA
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJTZWFyY2giOlt7IlRpdGxlIjoiU3RhciBXYXJzOiBFcGlzb2RlIElWIC0g
         QSBOZXcgSG9wZSIsIlllYXIiOiIxOTc3IiwiaW1kYklEIjoidHQwMDc2NzU5
-        IiwiVHlwZSI6Im1vdmllIiwiUG9zdGVyIjoiaHR0cDovL2lhLm1lZGlhLWlt
-        ZGIuY29tL2ltYWdlcy9NL01WNUJPVEl5TURZMk5HUXRPR0pqTmkwME9UazRM
-        V0ZoTURndFltRTNNMk5pWXpNMFlUVm1Ya0V5WGtGcWNHZGVRWFZ5TlRVMU5U
-        Y3dPVGtALl9WMV9TWDMwMC5qcGcifSx7IlRpdGxlIjoiU3RhciBXYXJzOiBF
-        cGlzb2RlIFYgLSBUaGUgRW1waXJlIFN0cmlrZXMgQmFjayIsIlllYXIiOiIx
-        OTgwIiwiaW1kYklEIjoidHQwMDgwNjg0IiwiVHlwZSI6Im1vdmllIiwiUG9z
-        dGVyIjoiaHR0cDovL2lhLm1lZGlhLWltZGIuY29tL2ltYWdlcy9NL01WNUJN
-        akUyTXpRd01UZ3hOMTVCTWw1QmFuQm5Ya0Z0WlRjd01EUXpOamsyT1FAQC5f
-        VjFfU1gzMDAuanBnIn0seyJUaXRsZSI6IlN0YXIgV2FyczogRXBpc29kZSBW
-        SSAtIFJldHVybiBvZiB0aGUgSmVkaSIsIlllYXIiOiIxOTgzIiwiaW1kYklE
-        IjoidHQwMDg2MTkwIiwiVHlwZSI6Im1vdmllIiwiUG9zdGVyIjoiaHR0cDov
-        L2lhLm1lZGlhLWltZGIuY29tL2ltYWdlcy9NL01WNUJNVFEwTXpJMU5qWXdP
-        RjVCTWw1QmFuQm5Ya0Z0WlRnd09EVTNORFUyTVRFQC5fVjEuX0NSOTMsOTcs
-        MTIwOSwxODYxX1NYODlfQUxfLmpwZ19WMV9TWDMwMC5qcGcifSx7IlRpdGxl
-        IjoiU3RhciBXYXJzOiBFcGlzb2RlIFZJSSAtIFRoZSBGb3JjZSBBd2FrZW5z
-        IiwiWWVhciI6IjIwMTUiLCJpbWRiSUQiOiJ0dDI0ODg0OTYiLCJUeXBlIjoi
-        bW92aWUiLCJQb3N0ZXIiOiJodHRwOi8vaWEubWVkaWEtaW1kYi5jb20vaW1h
-        Z2VzL00vTVY1Qk9UQXpPREV6TkRBek1sNUJNbDVCYW5CblhrRnRaVGd3TURV
-        MU1UZ3pOekVALl9WMV9TWDMwMC5qcGcifSx7IlRpdGxlIjoiU3RhciBXYXJz
-        OiBFcGlzb2RlIEkgLSBUaGUgUGhhbnRvbSBNZW5hY2UiLCJZZWFyIjoiMTk5
-        OSIsImltZGJJRCI6InR0MDEyMDkxNSIsIlR5cGUiOiJtb3ZpZSIsIlBvc3Rl
-        ciI6Imh0dHA6Ly9pYS5tZWRpYS1pbWRiLmNvbS9pbWFnZXMvTS9NVjVCTVRR
-        NE5qRXdOREEyTmw1Qk1sNUJhbkJuWGtGdFpUY3dORFV5TkRRek53QEAuX1Yx
-        X1NYMzAwLmpwZyJ9LHsiVGl0bGUiOiJTdGFyIFdhcnM6IEVwaXNvZGUgSUlJ
-        IC0gUmV2ZW5nZSBvZiB0aGUgU2l0aCIsIlllYXIiOiIyMDA1IiwiaW1kYklE
-        IjoidHQwMTIxNzY2IiwiVHlwZSI6Im1vdmllIiwiUG9zdGVyIjoiaHR0cDov
-        L2lhLm1lZGlhLWltZGIuY29tL2ltYWdlcy9NL01WNUJOVGM0TVRjM05UUTVP
-        RjVCTWw1QmFuQm5Ya0Z0WlRjd09UZzBOakk0TkFAQC5fVjFfU1gzMDAuanBn
-        In0seyJUaXRsZSI6IlN0YXIgV2FyczogRXBpc29kZSBJSSAtIEF0dGFjayBv
-        ZiB0aGUgQ2xvbmVzIiwiWWVhciI6IjIwMDIiLCJpbWRiSUQiOiJ0dDAxMjE3
-        NjUiLCJUeXBlIjoibW92aWUiLCJQb3N0ZXIiOiJodHRwOi8vaWEubWVkaWEt
-        aW1kYi5jb20vaW1hZ2VzL00vTVY1Qk1UWTVNakk1TlRJd05sNUJNbDVCYW5C
-        blhrRnRaVFl3TVRNMU5qZzIuX1YxX1NYMzAwLmpwZyJ9LHsiVGl0bGUiOiJT
-        dGFyIFdhcnM6IFRoZSBDbG9uZSBXYXJzIiwiWWVhciI6IjIwMDgiLCJpbWRi
-        SUQiOiJ0dDExODU4MzQiLCJUeXBlIjoibW92aWUiLCJQb3N0ZXIiOiJodHRw
-        Oi8vaWEubWVkaWEtaW1kYi5jb20vaW1hZ2VzL00vTVY1Qk1USTFNREl3TVRj
-        ek9WNUJNbDVCYW5CblhrRnRaVGN3TlRJNE1ERTNNUUBALl9WMV9TWDMwMC5q
-        cGcifSx7IlRpdGxlIjoiU3RhciBXYXJzOiBUaGUgQ2xvbmUgV2FycyIsIlll
-        YXIiOiIyMDA44oCTMjAxNSIsImltZGJJRCI6InR0MDQ1ODI5MCIsIlR5cGUi
-        OiJzZXJpZXMiLCJQb3N0ZXIiOiJodHRwOi8vaWEubWVkaWEtaW1kYi5jb20v
-        aW1hZ2VzL00vTVY1Qk1UTTBOalEyTWprME9WNUJNbDVCYW5CblhrRnRaVGN3
-        T0RRM05qYzNNZ0BALl9WMV9TWDMwMC5qcGcifSx7IlRpdGxlIjoiU3RhciBX
-        YXJzOiBDbG9uZSBXYXJzIiwiWWVhciI6IjIwMDPigJMyMDA1IiwiaW1kYklE
-        IjoidHQwMzYxMjQzIiwiVHlwZSI6InNlcmllcyIsIlBvc3RlciI6Imh0dHA6
-        Ly9pYS5tZWRpYS1pbWRiLmNvbS9pbWFnZXMvTS9NVjVCTWpFMk1qazVNemsz
-        TTE1Qk1sNUJhbkJuWGtGdFpUY3dNRGt6TVRJek1RQEAuX1YxX1NYMzAwLmpw
-        ZyJ9XSwidG90YWxSZXN1bHRzIjoiMzMzIiwiUmVzcG9uc2UiOiJUcnVlIn0=
+        IiwiVHlwZSI6Im1vdmllIiwiUG9zdGVyIjoiaHR0cHM6Ly9pbWFnZXMtbmEu
+        c3NsLWltYWdlcy1hbWF6b24uY29tL2ltYWdlcy9NL01WNUJZVFV3TlRkaU16
+        TXROVGhtTlMwME9EVXpMVGhsTURNdE1UTTVZMkprTldKak9HUTJYa0V5WGtG
+        cWNHZGVRWFZ5TnpRMU9EazNNVFFALl9WMV9TWDMwMC5qcGcifSx7IlRpdGxl
+        IjoiU3RhciBXYXJzOiBFcGlzb2RlIFYgLSBUaGUgRW1waXJlIFN0cmlrZXMg
+        QmFjayIsIlllYXIiOiIxOTgwIiwiaW1kYklEIjoidHQwMDgwNjg0IiwiVHlw
+        ZSI6Im1vdmllIiwiUG9zdGVyIjoiaHR0cHM6Ly9pbWFnZXMtbmEuc3NsLWlt
+        YWdlcy1hbWF6b24uY29tL2ltYWdlcy9NL01WNUJZbVZpWTJNMk1UWXRZMk16
+        T1MwMFlqUTFMV0l6WW1FdE9UQmlOamhsTUdNME5qWmpYa0V5WGtGcWNHZGVR
+        WFZ5TkRZeU1EazVNVFVALl9WMV9TWDMwMC5qcGcifSx7IlRpdGxlIjoiU3Rh
+        ciBXYXJzOiBFcGlzb2RlIFZJIC0gUmV0dXJuIG9mIHRoZSBKZWRpIiwiWWVh
+        ciI6IjE5ODMiLCJpbWRiSUQiOiJ0dDAwODYxOTAiLCJUeXBlIjoibW92aWUi
+        LCJQb3N0ZXIiOiJodHRwczovL2ltYWdlcy1uYS5zc2wtaW1hZ2VzLWFtYXpv
+        bi5jb20vaW1hZ2VzL00vTVY1Qk9EbGxaamcyWWpVdE5XRXpOeTAwWkdZMkxU
+        Z3labVF0WVRreE5EWXlPV00zT1RVeVhrRXlYa0ZxY0dkZVFYVnlNVFF4TnpN
+        ek5ESUAuX1YxX1NYMzAwLmpwZyJ9LHsiVGl0bGUiOiJTdGFyIFdhcnM6IFRo
+        ZSBGb3JjZSBBd2FrZW5zIiwiWWVhciI6IjIwMTUiLCJpbWRiSUQiOiJ0dDI0
+        ODg0OTYiLCJUeXBlIjoibW92aWUiLCJQb3N0ZXIiOiJodHRwczovL2ltYWdl
+        cy1uYS5zc2wtaW1hZ2VzLWFtYXpvbi5jb20vaW1hZ2VzL00vTVY1Qk9UQXpP
+        REV6TkRBek1sNUJNbDVCYW5CblhrRnRaVGd3TURVMU1UZ3pOekVALl9WMV9T
+        WDMwMC5qcGcifSx7IlRpdGxlIjoiU3RhciBXYXJzOiBFcGlzb2RlIEkgLSBU
+        aGUgUGhhbnRvbSBNZW5hY2UiLCJZZWFyIjoiMTk5OSIsImltZGJJRCI6InR0
+        MDEyMDkxNSIsIlR5cGUiOiJtb3ZpZSIsIlBvc3RlciI6Imh0dHBzOi8vaW1h
+        Z2VzLW5hLnNzbC1pbWFnZXMtYW1hem9uLmNvbS9pbWFnZXMvTS9NVjVCTTJG
+        bVpHSXdNekF0WlRCa01TMDBNMkppTFRrMk1EY3RNMkZsTlRRMk9XWXdaRFpr
+        WGtFeVhrRnFjR2RlUVhWeU5EWXlNRGs1TVRVQC5fVjFfU1gzMDAuanBnIn0s
+        eyJUaXRsZSI6IlN0YXIgV2FyczogRXBpc29kZSBJSUkgLSBSZXZlbmdlIG9m
+        IHRoZSBTaXRoIiwiWWVhciI6IjIwMDUiLCJpbWRiSUQiOiJ0dDAxMjE3NjYi
+        LCJUeXBlIjoibW92aWUiLCJQb3N0ZXIiOiJodHRwczovL2ltYWdlcy1uYS5z
+        c2wtaW1hZ2VzLWFtYXpvbi5jb20vaW1hZ2VzL00vTVY1Qk5UYzRNVGMzTlRR
+        NU9GNUJNbDVCYW5CblhrRnRaVGN3T1RnME5qSTROQUBALl9WMV9TWDMwMC5q
+        cGcifSx7IlRpdGxlIjoiU3RhciBXYXJzOiBFcGlzb2RlIElJIC0gQXR0YWNr
+        IG9mIHRoZSBDbG9uZXMiLCJZZWFyIjoiMjAwMiIsImltZGJJRCI6InR0MDEy
+        MTc2NSIsIlR5cGUiOiJtb3ZpZSIsIlBvc3RlciI6Imh0dHBzOi8vaW1hZ2Vz
+        LW5hLnNzbC1pbWFnZXMtYW1hem9uLmNvbS9pbWFnZXMvTS9NVjVCT1dOa1pt
+        VmpPREF0TlRGbFl5MDBOVFF3TFdKaFkyVXRNbUZtWlRreU9XSm1aalppTDJs
+        dFlXZGxMMmx0WVdkbFhrRXlYa0ZxY0dkZVFYVnlORFV6T1RRNU1qWUAuX1Yx
+        X1NYMzAwLmpwZyJ9LHsiVGl0bGUiOiJTdGFyIFdhcnM6IFRoZSBDbG9uZSBX
+        YXJzIiwiWWVhciI6IjIwMDgiLCJpbWRiSUQiOiJ0dDExODU4MzQiLCJUeXBl
+        IjoibW92aWUiLCJQb3N0ZXIiOiJodHRwczovL2ltYWdlcy1uYS5zc2wtaW1h
+        Z2VzLWFtYXpvbi5jb20vaW1hZ2VzL00vTVY1Qk1USTFNREl3TVRjek9WNUJN
+        bDVCYW5CblhrRnRaVGN3TlRJNE1ERTNNUUBALl9WMV9TWDMwMC5qcGcifSx7
+        IlRpdGxlIjoiU3RhciBXYXJzOiBUaGUgQ2xvbmUgV2FycyIsIlllYXIiOiIy
+        MDA44oCTMjAxNSIsImltZGJJRCI6InR0MDQ1ODI5MCIsIlR5cGUiOiJzZXJp
+        ZXMiLCJQb3N0ZXIiOiJodHRwczovL2ltYWdlcy1uYS5zc2wtaW1hZ2VzLWFt
+        YXpvbi5jb20vaW1hZ2VzL00vTVY1QllURmxaVEl4TVdRdFptWTBNaTAwWVdN
+        NUxXSmtZekF0Wm1ZM1pEa3daRGMwTldVMFhrRXlYa0ZxY0dkZVFYVnlNamc1
+        TkRNd01RQEAuX1YxX1NYMzAwLmpwZyJ9LHsiVGl0bGUiOiJTdGFyIFdhcnM6
+        IENsb25lIFdhcnMiLCJZZWFyIjoiMjAwM+KAkzIwMDUiLCJpbWRiSUQiOiJ0
+        dDAzNjEyNDMiLCJUeXBlIjoic2VyaWVzIiwiUG9zdGVyIjoiaHR0cHM6Ly9p
+        bWFnZXMtbmEuc3NsLWltYWdlcy1hbWF6b24uY29tL2ltYWdlcy9NL01WNUJN
+        emhtTlRnMU5XWXROVFV6TnkwME5XSTBMVGsxWm1ZdE9EQTFZVEUwTkdOa1lX
+        WmtYa0V5WGtGcWNHZGVRWFZ5TlRBeU9Ea3dPUUBALl9WMV9TWDMwMC5qcGci
+        fV0sInRvdGFsUmVzdWx0cyI6IjQwNiIsIlJlc3BvbnNlIjoiVHJ1ZSJ9
     http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:19:16 GMT
+  recorded_at: Sun, 08 Oct 2017 17:12:49 GMT
 - request:
     method: get
-    uri: http://omdbapi.com/?s=Star%20Wars
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&s=Star%20Wars
     body:
       encoding: US-ASCII
       string: ''
@@ -120,22 +127,22 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Jun 2016 20:19:16 GMT
+      - Sun, 08 Oct 2017 17:12:49 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
-      - close
+      - keep-alive
       Set-Cookie:
-      - __cfduid=d01d87248178e26be678b8e037840fb441465589956; expires=Sat, 10-Jun-17
-        20:19:16 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      - __cfduid=dcf4db7ac5f1a8a74c495bf12ce1002281507482769; expires=Mon, 08-Oct-18
+        17:12:49 GMT; path=/; domain=.omdbapi.com; HttpOnly
       Cache-Control:
-      - public, max-age=518
+      - public, max-age=3600
       Expires:
-      - Fri, 10 Jun 2016 20:27:52 GMT
+      - Sun, 08 Oct 2017 18:12:49 GMT
       Last-Modified:
-      - Fri, 10 Jun 2016 19:27:52 GMT
+      - Sun, 08 Oct 2017 17:12:49 GMT
       Vary:
       - "*"
       X-Aspnet-Version:
@@ -147,59 +154,66 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Cf-Ray:
-      - 2b0f846b6abe287c-SJC
+      - 3aaaba2e67002a31-SEA
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJTZWFyY2giOlt7IlRpdGxlIjoiU3RhciBXYXJzOiBFcGlzb2RlIElWIC0g
         QSBOZXcgSG9wZSIsIlllYXIiOiIxOTc3IiwiaW1kYklEIjoidHQwMDc2NzU5
-        IiwiVHlwZSI6Im1vdmllIiwiUG9zdGVyIjoiaHR0cDovL2lhLm1lZGlhLWlt
-        ZGIuY29tL2ltYWdlcy9NL01WNUJPVEl5TURZMk5HUXRPR0pqTmkwME9UazRM
-        V0ZoTURndFltRTNNMk5pWXpNMFlUVm1Ya0V5WGtGcWNHZGVRWFZ5TlRVMU5U
-        Y3dPVGtALl9WMV9TWDMwMC5qcGcifSx7IlRpdGxlIjoiU3RhciBXYXJzOiBF
-        cGlzb2RlIFYgLSBUaGUgRW1waXJlIFN0cmlrZXMgQmFjayIsIlllYXIiOiIx
-        OTgwIiwiaW1kYklEIjoidHQwMDgwNjg0IiwiVHlwZSI6Im1vdmllIiwiUG9z
-        dGVyIjoiaHR0cDovL2lhLm1lZGlhLWltZGIuY29tL2ltYWdlcy9NL01WNUJN
-        akUyTXpRd01UZ3hOMTVCTWw1QmFuQm5Ya0Z0WlRjd01EUXpOamsyT1FAQC5f
-        VjFfU1gzMDAuanBnIn0seyJUaXRsZSI6IlN0YXIgV2FyczogRXBpc29kZSBW
-        SSAtIFJldHVybiBvZiB0aGUgSmVkaSIsIlllYXIiOiIxOTgzIiwiaW1kYklE
-        IjoidHQwMDg2MTkwIiwiVHlwZSI6Im1vdmllIiwiUG9zdGVyIjoiaHR0cDov
-        L2lhLm1lZGlhLWltZGIuY29tL2ltYWdlcy9NL01WNUJNVFEwTXpJMU5qWXdP
-        RjVCTWw1QmFuQm5Ya0Z0WlRnd09EVTNORFUyTVRFQC5fVjEuX0NSOTMsOTcs
-        MTIwOSwxODYxX1NYODlfQUxfLmpwZ19WMV9TWDMwMC5qcGcifSx7IlRpdGxl
-        IjoiU3RhciBXYXJzOiBFcGlzb2RlIFZJSSAtIFRoZSBGb3JjZSBBd2FrZW5z
-        IiwiWWVhciI6IjIwMTUiLCJpbWRiSUQiOiJ0dDI0ODg0OTYiLCJUeXBlIjoi
-        bW92aWUiLCJQb3N0ZXIiOiJodHRwOi8vaWEubWVkaWEtaW1kYi5jb20vaW1h
-        Z2VzL00vTVY1Qk9UQXpPREV6TkRBek1sNUJNbDVCYW5CblhrRnRaVGd3TURV
-        MU1UZ3pOekVALl9WMV9TWDMwMC5qcGcifSx7IlRpdGxlIjoiU3RhciBXYXJz
-        OiBFcGlzb2RlIEkgLSBUaGUgUGhhbnRvbSBNZW5hY2UiLCJZZWFyIjoiMTk5
-        OSIsImltZGJJRCI6InR0MDEyMDkxNSIsIlR5cGUiOiJtb3ZpZSIsIlBvc3Rl
-        ciI6Imh0dHA6Ly9pYS5tZWRpYS1pbWRiLmNvbS9pbWFnZXMvTS9NVjVCTVRR
-        NE5qRXdOREEyTmw1Qk1sNUJhbkJuWGtGdFpUY3dORFV5TkRRek53QEAuX1Yx
-        X1NYMzAwLmpwZyJ9LHsiVGl0bGUiOiJTdGFyIFdhcnM6IEVwaXNvZGUgSUlJ
-        IC0gUmV2ZW5nZSBvZiB0aGUgU2l0aCIsIlllYXIiOiIyMDA1IiwiaW1kYklE
-        IjoidHQwMTIxNzY2IiwiVHlwZSI6Im1vdmllIiwiUG9zdGVyIjoiaHR0cDov
-        L2lhLm1lZGlhLWltZGIuY29tL2ltYWdlcy9NL01WNUJOVGM0TVRjM05UUTVP
-        RjVCTWw1QmFuQm5Ya0Z0WlRjd09UZzBOakk0TkFAQC5fVjFfU1gzMDAuanBn
-        In0seyJUaXRsZSI6IlN0YXIgV2FyczogRXBpc29kZSBJSSAtIEF0dGFjayBv
-        ZiB0aGUgQ2xvbmVzIiwiWWVhciI6IjIwMDIiLCJpbWRiSUQiOiJ0dDAxMjE3
-        NjUiLCJUeXBlIjoibW92aWUiLCJQb3N0ZXIiOiJodHRwOi8vaWEubWVkaWEt
-        aW1kYi5jb20vaW1hZ2VzL00vTVY1Qk1UWTVNakk1TlRJd05sNUJNbDVCYW5C
-        blhrRnRaVFl3TVRNMU5qZzIuX1YxX1NYMzAwLmpwZyJ9LHsiVGl0bGUiOiJT
-        dGFyIFdhcnM6IFRoZSBDbG9uZSBXYXJzIiwiWWVhciI6IjIwMDgiLCJpbWRi
-        SUQiOiJ0dDExODU4MzQiLCJUeXBlIjoibW92aWUiLCJQb3N0ZXIiOiJodHRw
-        Oi8vaWEubWVkaWEtaW1kYi5jb20vaW1hZ2VzL00vTVY1Qk1USTFNREl3TVRj
-        ek9WNUJNbDVCYW5CblhrRnRaVGN3TlRJNE1ERTNNUUBALl9WMV9TWDMwMC5q
-        cGcifSx7IlRpdGxlIjoiU3RhciBXYXJzOiBUaGUgQ2xvbmUgV2FycyIsIlll
-        YXIiOiIyMDA44oCTMjAxNSIsImltZGJJRCI6InR0MDQ1ODI5MCIsIlR5cGUi
-        OiJzZXJpZXMiLCJQb3N0ZXIiOiJodHRwOi8vaWEubWVkaWEtaW1kYi5jb20v
-        aW1hZ2VzL00vTVY1Qk1UTTBOalEyTWprME9WNUJNbDVCYW5CblhrRnRaVGN3
-        T0RRM05qYzNNZ0BALl9WMV9TWDMwMC5qcGcifSx7IlRpdGxlIjoiU3RhciBX
-        YXJzOiBDbG9uZSBXYXJzIiwiWWVhciI6IjIwMDPigJMyMDA1IiwiaW1kYklE
-        IjoidHQwMzYxMjQzIiwiVHlwZSI6InNlcmllcyIsIlBvc3RlciI6Imh0dHA6
-        Ly9pYS5tZWRpYS1pbWRiLmNvbS9pbWFnZXMvTS9NVjVCTWpFMk1qazVNemsz
-        TTE1Qk1sNUJhbkJuWGtGdFpUY3dNRGt6TVRJek1RQEAuX1YxX1NYMzAwLmpw
-        ZyJ9XSwidG90YWxSZXN1bHRzIjoiMzMzIiwiUmVzcG9uc2UiOiJUcnVlIn0=
+        IiwiVHlwZSI6Im1vdmllIiwiUG9zdGVyIjoiaHR0cHM6Ly9pbWFnZXMtbmEu
+        c3NsLWltYWdlcy1hbWF6b24uY29tL2ltYWdlcy9NL01WNUJZVFV3TlRkaU16
+        TXROVGhtTlMwME9EVXpMVGhsTURNdE1UTTVZMkprTldKak9HUTJYa0V5WGtG
+        cWNHZGVRWFZ5TnpRMU9EazNNVFFALl9WMV9TWDMwMC5qcGcifSx7IlRpdGxl
+        IjoiU3RhciBXYXJzOiBFcGlzb2RlIFYgLSBUaGUgRW1waXJlIFN0cmlrZXMg
+        QmFjayIsIlllYXIiOiIxOTgwIiwiaW1kYklEIjoidHQwMDgwNjg0IiwiVHlw
+        ZSI6Im1vdmllIiwiUG9zdGVyIjoiaHR0cHM6Ly9pbWFnZXMtbmEuc3NsLWlt
+        YWdlcy1hbWF6b24uY29tL2ltYWdlcy9NL01WNUJZbVZpWTJNMk1UWXRZMk16
+        T1MwMFlqUTFMV0l6WW1FdE9UQmlOamhsTUdNME5qWmpYa0V5WGtGcWNHZGVR
+        WFZ5TkRZeU1EazVNVFVALl9WMV9TWDMwMC5qcGcifSx7IlRpdGxlIjoiU3Rh
+        ciBXYXJzOiBFcGlzb2RlIFZJIC0gUmV0dXJuIG9mIHRoZSBKZWRpIiwiWWVh
+        ciI6IjE5ODMiLCJpbWRiSUQiOiJ0dDAwODYxOTAiLCJUeXBlIjoibW92aWUi
+        LCJQb3N0ZXIiOiJodHRwczovL2ltYWdlcy1uYS5zc2wtaW1hZ2VzLWFtYXpv
+        bi5jb20vaW1hZ2VzL00vTVY1Qk9EbGxaamcyWWpVdE5XRXpOeTAwWkdZMkxU
+        Z3labVF0WVRreE5EWXlPV00zT1RVeVhrRXlYa0ZxY0dkZVFYVnlNVFF4TnpN
+        ek5ESUAuX1YxX1NYMzAwLmpwZyJ9LHsiVGl0bGUiOiJTdGFyIFdhcnM6IFRo
+        ZSBGb3JjZSBBd2FrZW5zIiwiWWVhciI6IjIwMTUiLCJpbWRiSUQiOiJ0dDI0
+        ODg0OTYiLCJUeXBlIjoibW92aWUiLCJQb3N0ZXIiOiJodHRwczovL2ltYWdl
+        cy1uYS5zc2wtaW1hZ2VzLWFtYXpvbi5jb20vaW1hZ2VzL00vTVY1Qk9UQXpP
+        REV6TkRBek1sNUJNbDVCYW5CblhrRnRaVGd3TURVMU1UZ3pOekVALl9WMV9T
+        WDMwMC5qcGcifSx7IlRpdGxlIjoiU3RhciBXYXJzOiBFcGlzb2RlIEkgLSBU
+        aGUgUGhhbnRvbSBNZW5hY2UiLCJZZWFyIjoiMTk5OSIsImltZGJJRCI6InR0
+        MDEyMDkxNSIsIlR5cGUiOiJtb3ZpZSIsIlBvc3RlciI6Imh0dHBzOi8vaW1h
+        Z2VzLW5hLnNzbC1pbWFnZXMtYW1hem9uLmNvbS9pbWFnZXMvTS9NVjVCTTJG
+        bVpHSXdNekF0WlRCa01TMDBNMkppTFRrMk1EY3RNMkZsTlRRMk9XWXdaRFpr
+        WGtFeVhrRnFjR2RlUVhWeU5EWXlNRGs1TVRVQC5fVjFfU1gzMDAuanBnIn0s
+        eyJUaXRsZSI6IlN0YXIgV2FyczogRXBpc29kZSBJSUkgLSBSZXZlbmdlIG9m
+        IHRoZSBTaXRoIiwiWWVhciI6IjIwMDUiLCJpbWRiSUQiOiJ0dDAxMjE3NjYi
+        LCJUeXBlIjoibW92aWUiLCJQb3N0ZXIiOiJodHRwczovL2ltYWdlcy1uYS5z
+        c2wtaW1hZ2VzLWFtYXpvbi5jb20vaW1hZ2VzL00vTVY1Qk5UYzRNVGMzTlRR
+        NU9GNUJNbDVCYW5CblhrRnRaVGN3T1RnME5qSTROQUBALl9WMV9TWDMwMC5q
+        cGcifSx7IlRpdGxlIjoiU3RhciBXYXJzOiBFcGlzb2RlIElJIC0gQXR0YWNr
+        IG9mIHRoZSBDbG9uZXMiLCJZZWFyIjoiMjAwMiIsImltZGJJRCI6InR0MDEy
+        MTc2NSIsIlR5cGUiOiJtb3ZpZSIsIlBvc3RlciI6Imh0dHBzOi8vaW1hZ2Vz
+        LW5hLnNzbC1pbWFnZXMtYW1hem9uLmNvbS9pbWFnZXMvTS9NVjVCT1dOa1pt
+        VmpPREF0TlRGbFl5MDBOVFF3TFdKaFkyVXRNbUZtWlRreU9XSm1aalppTDJs
+        dFlXZGxMMmx0WVdkbFhrRXlYa0ZxY0dkZVFYVnlORFV6T1RRNU1qWUAuX1Yx
+        X1NYMzAwLmpwZyJ9LHsiVGl0bGUiOiJTdGFyIFdhcnM6IFRoZSBDbG9uZSBX
+        YXJzIiwiWWVhciI6IjIwMDgiLCJpbWRiSUQiOiJ0dDExODU4MzQiLCJUeXBl
+        IjoibW92aWUiLCJQb3N0ZXIiOiJodHRwczovL2ltYWdlcy1uYS5zc2wtaW1h
+        Z2VzLWFtYXpvbi5jb20vaW1hZ2VzL00vTVY1Qk1USTFNREl3TVRjek9WNUJN
+        bDVCYW5CblhrRnRaVGN3TlRJNE1ERTNNUUBALl9WMV9TWDMwMC5qcGcifSx7
+        IlRpdGxlIjoiU3RhciBXYXJzOiBUaGUgQ2xvbmUgV2FycyIsIlllYXIiOiIy
+        MDA44oCTMjAxNSIsImltZGJJRCI6InR0MDQ1ODI5MCIsIlR5cGUiOiJzZXJp
+        ZXMiLCJQb3N0ZXIiOiJodHRwczovL2ltYWdlcy1uYS5zc2wtaW1hZ2VzLWFt
+        YXpvbi5jb20vaW1hZ2VzL00vTVY1QllURmxaVEl4TVdRdFptWTBNaTAwWVdN
+        NUxXSmtZekF0Wm1ZM1pEa3daRGMwTldVMFhrRXlYa0ZxY0dkZVFYVnlNamc1
+        TkRNd01RQEAuX1YxX1NYMzAwLmpwZyJ9LHsiVGl0bGUiOiJTdGFyIFdhcnM6
+        IENsb25lIFdhcnMiLCJZZWFyIjoiMjAwM+KAkzIwMDUiLCJpbWRiSUQiOiJ0
+        dDAzNjEyNDMiLCJUeXBlIjoic2VyaWVzIiwiUG9zdGVyIjoiaHR0cHM6Ly9p
+        bWFnZXMtbmEuc3NsLWltYWdlcy1hbWF6b24uY29tL2ltYWdlcy9NL01WNUJN
+        emhtTlRnMU5XWXROVFV6TnkwME5XSTBMVGsxWm1ZdE9EQTFZVEUwTkdOa1lX
+        WmtYa0V5WGtGcWNHZGVRWFZ5TlRBeU9Ea3dPUUBALl9WMV9TWDMwMC5qcGci
+        fV0sInRvdGFsUmVzdWx0cyI6IjQwNiIsIlJlc3BvbnNlIjoiVHJ1ZSJ9
     http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:19:16 GMT
+  recorded_at: Sun, 08 Oct 2017 17:12:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/search/result.yml
+++ b/spec/vcr/search/result.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://omdbapi.com/?s=Star%20Wars%20Episode%20IV%20A%20New%20Hope
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&s=Star%20Wars%20Episode%20IV%20A%20New%20Hope
     body:
       encoding: US-ASCII
       string: ''
@@ -19,22 +19,74 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Jun 2016 20:19:16 GMT
+      - Sun, 08 Oct 2017 17:12:49 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
-      - close
+      - keep-alive
       Set-Cookie:
-      - __cfduid=d7cc1bb0698b25cbf70bcbe75cb32053d1465589955; expires=Sat, 10-Jun-17
-        20:19:15 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      - __cfduid=dfe972d0c8f58e38f5360849a6e1ede471507482769; expires=Mon, 08-Oct-18
+        17:12:49 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      Cache-Control:
+      - public, max-age=3508
+      Expires:
+      - Sun, 08 Oct 2017 18:11:17 GMT
+      Last-Modified:
+      - Sun, 08 Oct 2017 17:11:17 GMT
+      Vary:
+      - "*"
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare-nginx
+      Cf-Ray:
+      - 3aaaba2bb2c82a79-SEA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"Search":[{"Title":"Star Wars: Episode IV - A New Hope","Year":"1977","imdbID":"tt0076759","Type":"movie","Poster":"https://images-na.ssl-images-amazon.com/images/M/MV5BYTUwNTdiMzMtNThmNS00ODUzLThlMDMtMTM5Y2JkNWJjOGQ2XkEyXkFqcGdeQXVyNzQ1ODk3MTQ@._V1_SX300.jpg"}],"totalResults":"1","Response":"True"}'
+    http_version: 
+  recorded_at: Sun, 08 Oct 2017 17:12:49 GMT
+- request:
+    method: get
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&t=Star%20Wars:%20Episode%20IV%20-%20A%20New%20Hope
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 08 Oct 2017 17:12:49 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d9bf6019ef11b0892c4c0ea426f2166a91507482769; expires=Mon, 08-Oct-18
+        17:12:49 GMT; path=/; domain=.omdbapi.com; HttpOnly
       Cache-Control:
       - public, max-age=3600
       Expires:
-      - Fri, 10 Jun 2016 21:19:14 GMT
+      - Sun, 08 Oct 2017 18:12:49 GMT
       Last-Modified:
-      - Fri, 10 Jun 2016 20:19:14 GMT
+      - Sun, 08 Oct 2017 17:12:49 GMT
       Vary:
       - "*"
       X-Aspnet-Version:
@@ -46,69 +98,19 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Cf-Ray:
-      - 2b0f8468469c28ac-SJC
-    body:
-      encoding: ASCII-8BIT
-      string: '{"Search":[{"Title":"Star Wars: Episode IV - A New Hope","Year":"1977","imdbID":"tt0076759","Type":"movie","Poster":"http://ia.media-imdb.com/images/M/MV5BOTIyMDY2NGQtOGJjNi00OTk4LWFhMDgtYmE3M2NiYzM0YTVmXkEyXkFqcGdeQXVyNTU1NTcwOTk@._V1_SX300.jpg"}],"totalResults":"1","Response":"True"}'
-    http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:19:16 GMT
-- request:
-    method: get
-    uri: http://omdbapi.com/?t=Star%20Wars:%20Episode%20IV%20-%20A%20New%20Hope
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 10 Jun 2016 20:19:16 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - close
-      Set-Cookie:
-      - __cfduid=da7258e3fe903e2234610956a808e9f751465589956; expires=Sat, 10-Jun-17
-        20:19:16 GMT; path=/; domain=.omdbapi.com; HttpOnly
-      Cache-Control:
-      - public, max-age=3161
-      Expires:
-      - Fri, 10 Jun 2016 21:11:55 GMT
-      Last-Modified:
-      - Fri, 10 Jun 2016 20:11:55 GMT
-      Vary:
-      - "*"
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Powered-By:
-      - ASP.NET
-      Access-Control-Allow-Origin:
-      - "*"
-      Server:
-      - cloudflare-nginx
-      Cf-Ray:
-      - 2b0f8469682911c5-SJC
+      - 3aaaba2c67bd7a1d-SEA
     body:
       encoding: ASCII-8BIT
       string: '{"Title":"Star Wars: Episode IV - A New Hope","Year":"1977","Rated":"PG","Released":"25
         May 1977","Runtime":"121 min","Genre":"Action, Adventure, Fantasy","Director":"George
         Lucas","Writer":"George Lucas","Actors":"Mark Hamill, Harrison Ford, Carrie
         Fisher, Peter Cushing","Plot":"Luke Skywalker joins forces with a Jedi Knight,
-        a cocky pilot, a wookiee and two droids to save the galaxy from the Empire''s
+        a cocky pilot, a Wookiee, and two droids to save the galaxy from the Empire''s
         world-destroying battle-station, while also attempting to rescue Princess
         Leia from the evil Darth Vader.","Language":"English","Country":"USA","Awards":"Won
-        6 Oscars. Another 39 wins & 28 nominations.","Poster":"http://ia.media-imdb.com/images/M/MV5BOTIyMDY2NGQtOGJjNi00OTk4LWFhMDgtYmE3M2NiYzM0YTVmXkEyXkFqcGdeQXVyNTU1NTcwOTk@._V1_SX300.jpg","Metascore":"92","imdbRating":"8.7","imdbVotes":"894,008","imdbID":"tt0076759","Type":"movie","Response":"True"}'
+        6 Oscars. Another 50 wins & 28 nominations.","Poster":"https://images-na.ssl-images-amazon.com/images/M/MV5BYTUwNTdiMzMtNThmNS00ODUzLThlMDMtMTM5Y2JkNWJjOGQ2XkEyXkFqcGdeQXVyNzQ1ODk3MTQ@._V1_SX300.jpg","Ratings":[{"Source":"Internet
+        Movie Database","Value":"8.7/10"},{"Source":"Rotten Tomatoes","Value":"93%"},{"Source":"Metacritic","Value":"92/100"}],"Metascore":"92","imdbRating":"8.7","imdbVotes":"999,345","imdbID":"tt0076759","Type":"movie","DVD":"21
+        Sep 2004","BoxOffice":"N/A","Production":"20th Century Fox","Website":"http://www.starwars.com/episode-iv/","Response":"True"}'
     http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:19:16 GMT
+  recorded_at: Sun, 08 Oct 2017 17:12:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/search/results.yml
+++ b/spec/vcr/search/results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://omdbapi.com/?s=Star%20Wars
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&s=Star%20Wars
     body:
       encoding: US-ASCII
       string: ''
@@ -19,22 +19,22 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Jun 2016 20:19:15 GMT
+      - Sun, 08 Oct 2017 17:12:49 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
-      - close
+      - keep-alive
       Set-Cookie:
-      - __cfduid=dc67b5a36363971db619743939b3deaa31465589955; expires=Sat, 10-Jun-17
-        20:19:15 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      - __cfduid=d84ccc422a9ccd4acd7a1c1c86d9ae15b1507482769; expires=Mon, 08-Oct-18
+        17:12:49 GMT; path=/; domain=.omdbapi.com; HttpOnly
       Cache-Control:
-      - public, max-age=518
+      - public, max-age=3509
       Expires:
-      - Fri, 10 Jun 2016 20:27:52 GMT
+      - Sun, 08 Oct 2017 18:11:18 GMT
       Last-Modified:
-      - Fri, 10 Jun 2016 19:27:52 GMT
+      - Sun, 08 Oct 2017 17:11:18 GMT
       Vary:
       - "*"
       X-Aspnet-Version:
@@ -46,59 +46,66 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Cf-Ray:
-      - 2b0f8466d8bf1e83-SJC
+      - 3aaaba2b00931bd3-SEA
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJTZWFyY2giOlt7IlRpdGxlIjoiU3RhciBXYXJzOiBFcGlzb2RlIElWIC0g
         QSBOZXcgSG9wZSIsIlllYXIiOiIxOTc3IiwiaW1kYklEIjoidHQwMDc2NzU5
-        IiwiVHlwZSI6Im1vdmllIiwiUG9zdGVyIjoiaHR0cDovL2lhLm1lZGlhLWlt
-        ZGIuY29tL2ltYWdlcy9NL01WNUJPVEl5TURZMk5HUXRPR0pqTmkwME9UazRM
-        V0ZoTURndFltRTNNMk5pWXpNMFlUVm1Ya0V5WGtGcWNHZGVRWFZ5TlRVMU5U
-        Y3dPVGtALl9WMV9TWDMwMC5qcGcifSx7IlRpdGxlIjoiU3RhciBXYXJzOiBF
-        cGlzb2RlIFYgLSBUaGUgRW1waXJlIFN0cmlrZXMgQmFjayIsIlllYXIiOiIx
-        OTgwIiwiaW1kYklEIjoidHQwMDgwNjg0IiwiVHlwZSI6Im1vdmllIiwiUG9z
-        dGVyIjoiaHR0cDovL2lhLm1lZGlhLWltZGIuY29tL2ltYWdlcy9NL01WNUJN
-        akUyTXpRd01UZ3hOMTVCTWw1QmFuQm5Ya0Z0WlRjd01EUXpOamsyT1FAQC5f
-        VjFfU1gzMDAuanBnIn0seyJUaXRsZSI6IlN0YXIgV2FyczogRXBpc29kZSBW
-        SSAtIFJldHVybiBvZiB0aGUgSmVkaSIsIlllYXIiOiIxOTgzIiwiaW1kYklE
-        IjoidHQwMDg2MTkwIiwiVHlwZSI6Im1vdmllIiwiUG9zdGVyIjoiaHR0cDov
-        L2lhLm1lZGlhLWltZGIuY29tL2ltYWdlcy9NL01WNUJNVFEwTXpJMU5qWXdP
-        RjVCTWw1QmFuQm5Ya0Z0WlRnd09EVTNORFUyTVRFQC5fVjEuX0NSOTMsOTcs
-        MTIwOSwxODYxX1NYODlfQUxfLmpwZ19WMV9TWDMwMC5qcGcifSx7IlRpdGxl
-        IjoiU3RhciBXYXJzOiBFcGlzb2RlIFZJSSAtIFRoZSBGb3JjZSBBd2FrZW5z
-        IiwiWWVhciI6IjIwMTUiLCJpbWRiSUQiOiJ0dDI0ODg0OTYiLCJUeXBlIjoi
-        bW92aWUiLCJQb3N0ZXIiOiJodHRwOi8vaWEubWVkaWEtaW1kYi5jb20vaW1h
-        Z2VzL00vTVY1Qk9UQXpPREV6TkRBek1sNUJNbDVCYW5CblhrRnRaVGd3TURV
-        MU1UZ3pOekVALl9WMV9TWDMwMC5qcGcifSx7IlRpdGxlIjoiU3RhciBXYXJz
-        OiBFcGlzb2RlIEkgLSBUaGUgUGhhbnRvbSBNZW5hY2UiLCJZZWFyIjoiMTk5
-        OSIsImltZGJJRCI6InR0MDEyMDkxNSIsIlR5cGUiOiJtb3ZpZSIsIlBvc3Rl
-        ciI6Imh0dHA6Ly9pYS5tZWRpYS1pbWRiLmNvbS9pbWFnZXMvTS9NVjVCTVRR
-        NE5qRXdOREEyTmw1Qk1sNUJhbkJuWGtGdFpUY3dORFV5TkRRek53QEAuX1Yx
-        X1NYMzAwLmpwZyJ9LHsiVGl0bGUiOiJTdGFyIFdhcnM6IEVwaXNvZGUgSUlJ
-        IC0gUmV2ZW5nZSBvZiB0aGUgU2l0aCIsIlllYXIiOiIyMDA1IiwiaW1kYklE
-        IjoidHQwMTIxNzY2IiwiVHlwZSI6Im1vdmllIiwiUG9zdGVyIjoiaHR0cDov
-        L2lhLm1lZGlhLWltZGIuY29tL2ltYWdlcy9NL01WNUJOVGM0TVRjM05UUTVP
-        RjVCTWw1QmFuQm5Ya0Z0WlRjd09UZzBOakk0TkFAQC5fVjFfU1gzMDAuanBn
-        In0seyJUaXRsZSI6IlN0YXIgV2FyczogRXBpc29kZSBJSSAtIEF0dGFjayBv
-        ZiB0aGUgQ2xvbmVzIiwiWWVhciI6IjIwMDIiLCJpbWRiSUQiOiJ0dDAxMjE3
-        NjUiLCJUeXBlIjoibW92aWUiLCJQb3N0ZXIiOiJodHRwOi8vaWEubWVkaWEt
-        aW1kYi5jb20vaW1hZ2VzL00vTVY1Qk1UWTVNakk1TlRJd05sNUJNbDVCYW5C
-        blhrRnRaVFl3TVRNMU5qZzIuX1YxX1NYMzAwLmpwZyJ9LHsiVGl0bGUiOiJT
-        dGFyIFdhcnM6IFRoZSBDbG9uZSBXYXJzIiwiWWVhciI6IjIwMDgiLCJpbWRi
-        SUQiOiJ0dDExODU4MzQiLCJUeXBlIjoibW92aWUiLCJQb3N0ZXIiOiJodHRw
-        Oi8vaWEubWVkaWEtaW1kYi5jb20vaW1hZ2VzL00vTVY1Qk1USTFNREl3TVRj
-        ek9WNUJNbDVCYW5CblhrRnRaVGN3TlRJNE1ERTNNUUBALl9WMV9TWDMwMC5q
-        cGcifSx7IlRpdGxlIjoiU3RhciBXYXJzOiBUaGUgQ2xvbmUgV2FycyIsIlll
-        YXIiOiIyMDA44oCTMjAxNSIsImltZGJJRCI6InR0MDQ1ODI5MCIsIlR5cGUi
-        OiJzZXJpZXMiLCJQb3N0ZXIiOiJodHRwOi8vaWEubWVkaWEtaW1kYi5jb20v
-        aW1hZ2VzL00vTVY1Qk1UTTBOalEyTWprME9WNUJNbDVCYW5CblhrRnRaVGN3
-        T0RRM05qYzNNZ0BALl9WMV9TWDMwMC5qcGcifSx7IlRpdGxlIjoiU3RhciBX
-        YXJzOiBDbG9uZSBXYXJzIiwiWWVhciI6IjIwMDPigJMyMDA1IiwiaW1kYklE
-        IjoidHQwMzYxMjQzIiwiVHlwZSI6InNlcmllcyIsIlBvc3RlciI6Imh0dHA6
-        Ly9pYS5tZWRpYS1pbWRiLmNvbS9pbWFnZXMvTS9NVjVCTWpFMk1qazVNemsz
-        TTE1Qk1sNUJhbkJuWGtGdFpUY3dNRGt6TVRJek1RQEAuX1YxX1NYMzAwLmpw
-        ZyJ9XSwidG90YWxSZXN1bHRzIjoiMzMzIiwiUmVzcG9uc2UiOiJUcnVlIn0=
+        IiwiVHlwZSI6Im1vdmllIiwiUG9zdGVyIjoiaHR0cHM6Ly9pbWFnZXMtbmEu
+        c3NsLWltYWdlcy1hbWF6b24uY29tL2ltYWdlcy9NL01WNUJZVFV3TlRkaU16
+        TXROVGhtTlMwME9EVXpMVGhsTURNdE1UTTVZMkprTldKak9HUTJYa0V5WGtG
+        cWNHZGVRWFZ5TnpRMU9EazNNVFFALl9WMV9TWDMwMC5qcGcifSx7IlRpdGxl
+        IjoiU3RhciBXYXJzOiBFcGlzb2RlIFYgLSBUaGUgRW1waXJlIFN0cmlrZXMg
+        QmFjayIsIlllYXIiOiIxOTgwIiwiaW1kYklEIjoidHQwMDgwNjg0IiwiVHlw
+        ZSI6Im1vdmllIiwiUG9zdGVyIjoiaHR0cHM6Ly9pbWFnZXMtbmEuc3NsLWlt
+        YWdlcy1hbWF6b24uY29tL2ltYWdlcy9NL01WNUJZbVZpWTJNMk1UWXRZMk16
+        T1MwMFlqUTFMV0l6WW1FdE9UQmlOamhsTUdNME5qWmpYa0V5WGtGcWNHZGVR
+        WFZ5TkRZeU1EazVNVFVALl9WMV9TWDMwMC5qcGcifSx7IlRpdGxlIjoiU3Rh
+        ciBXYXJzOiBFcGlzb2RlIFZJIC0gUmV0dXJuIG9mIHRoZSBKZWRpIiwiWWVh
+        ciI6IjE5ODMiLCJpbWRiSUQiOiJ0dDAwODYxOTAiLCJUeXBlIjoibW92aWUi
+        LCJQb3N0ZXIiOiJodHRwczovL2ltYWdlcy1uYS5zc2wtaW1hZ2VzLWFtYXpv
+        bi5jb20vaW1hZ2VzL00vTVY1Qk9EbGxaamcyWWpVdE5XRXpOeTAwWkdZMkxU
+        Z3labVF0WVRreE5EWXlPV00zT1RVeVhrRXlYa0ZxY0dkZVFYVnlNVFF4TnpN
+        ek5ESUAuX1YxX1NYMzAwLmpwZyJ9LHsiVGl0bGUiOiJTdGFyIFdhcnM6IFRo
+        ZSBGb3JjZSBBd2FrZW5zIiwiWWVhciI6IjIwMTUiLCJpbWRiSUQiOiJ0dDI0
+        ODg0OTYiLCJUeXBlIjoibW92aWUiLCJQb3N0ZXIiOiJodHRwczovL2ltYWdl
+        cy1uYS5zc2wtaW1hZ2VzLWFtYXpvbi5jb20vaW1hZ2VzL00vTVY1Qk9UQXpP
+        REV6TkRBek1sNUJNbDVCYW5CblhrRnRaVGd3TURVMU1UZ3pOekVALl9WMV9T
+        WDMwMC5qcGcifSx7IlRpdGxlIjoiU3RhciBXYXJzOiBFcGlzb2RlIEkgLSBU
+        aGUgUGhhbnRvbSBNZW5hY2UiLCJZZWFyIjoiMTk5OSIsImltZGJJRCI6InR0
+        MDEyMDkxNSIsIlR5cGUiOiJtb3ZpZSIsIlBvc3RlciI6Imh0dHBzOi8vaW1h
+        Z2VzLW5hLnNzbC1pbWFnZXMtYW1hem9uLmNvbS9pbWFnZXMvTS9NVjVCTTJG
+        bVpHSXdNekF0WlRCa01TMDBNMkppTFRrMk1EY3RNMkZsTlRRMk9XWXdaRFpr
+        WGtFeVhrRnFjR2RlUVhWeU5EWXlNRGs1TVRVQC5fVjFfU1gzMDAuanBnIn0s
+        eyJUaXRsZSI6IlN0YXIgV2FyczogRXBpc29kZSBJSUkgLSBSZXZlbmdlIG9m
+        IHRoZSBTaXRoIiwiWWVhciI6IjIwMDUiLCJpbWRiSUQiOiJ0dDAxMjE3NjYi
+        LCJUeXBlIjoibW92aWUiLCJQb3N0ZXIiOiJodHRwczovL2ltYWdlcy1uYS5z
+        c2wtaW1hZ2VzLWFtYXpvbi5jb20vaW1hZ2VzL00vTVY1Qk5UYzRNVGMzTlRR
+        NU9GNUJNbDVCYW5CblhrRnRaVGN3T1RnME5qSTROQUBALl9WMV9TWDMwMC5q
+        cGcifSx7IlRpdGxlIjoiU3RhciBXYXJzOiBFcGlzb2RlIElJIC0gQXR0YWNr
+        IG9mIHRoZSBDbG9uZXMiLCJZZWFyIjoiMjAwMiIsImltZGJJRCI6InR0MDEy
+        MTc2NSIsIlR5cGUiOiJtb3ZpZSIsIlBvc3RlciI6Imh0dHBzOi8vaW1hZ2Vz
+        LW5hLnNzbC1pbWFnZXMtYW1hem9uLmNvbS9pbWFnZXMvTS9NVjVCT1dOa1pt
+        VmpPREF0TlRGbFl5MDBOVFF3TFdKaFkyVXRNbUZtWlRreU9XSm1aalppTDJs
+        dFlXZGxMMmx0WVdkbFhrRXlYa0ZxY0dkZVFYVnlORFV6T1RRNU1qWUAuX1Yx
+        X1NYMzAwLmpwZyJ9LHsiVGl0bGUiOiJTdGFyIFdhcnM6IFRoZSBDbG9uZSBX
+        YXJzIiwiWWVhciI6IjIwMDgiLCJpbWRiSUQiOiJ0dDExODU4MzQiLCJUeXBl
+        IjoibW92aWUiLCJQb3N0ZXIiOiJodHRwczovL2ltYWdlcy1uYS5zc2wtaW1h
+        Z2VzLWFtYXpvbi5jb20vaW1hZ2VzL00vTVY1Qk1USTFNREl3TVRjek9WNUJN
+        bDVCYW5CblhrRnRaVGN3TlRJNE1ERTNNUUBALl9WMV9TWDMwMC5qcGcifSx7
+        IlRpdGxlIjoiU3RhciBXYXJzOiBUaGUgQ2xvbmUgV2FycyIsIlllYXIiOiIy
+        MDA44oCTMjAxNSIsImltZGJJRCI6InR0MDQ1ODI5MCIsIlR5cGUiOiJzZXJp
+        ZXMiLCJQb3N0ZXIiOiJodHRwczovL2ltYWdlcy1uYS5zc2wtaW1hZ2VzLWFt
+        YXpvbi5jb20vaW1hZ2VzL00vTVY1QllURmxaVEl4TVdRdFptWTBNaTAwWVdN
+        NUxXSmtZekF0Wm1ZM1pEa3daRGMwTldVMFhrRXlYa0ZxY0dkZVFYVnlNamc1
+        TkRNd01RQEAuX1YxX1NYMzAwLmpwZyJ9LHsiVGl0bGUiOiJTdGFyIFdhcnM6
+        IENsb25lIFdhcnMiLCJZZWFyIjoiMjAwM+KAkzIwMDUiLCJpbWRiSUQiOiJ0
+        dDAzNjEyNDMiLCJUeXBlIjoic2VyaWVzIiwiUG9zdGVyIjoiaHR0cHM6Ly9p
+        bWFnZXMtbmEuc3NsLWltYWdlcy1hbWF6b24uY29tL2ltYWdlcy9NL01WNUJN
+        emhtTlRnMU5XWXROVFV6TnkwME5XSTBMVGsxWm1ZdE9EQTFZVEUwTkdOa1lX
+        WmtYa0V5WGtGcWNHZGVRWFZ5TlRBeU9Ea3dPUUBALl9WMV9TWDMwMC5qcGci
+        fV0sInRvdGFsUmVzdWx0cyI6IjQwNiIsIlJlc3BvbnNlIjoiVHJ1ZSJ9
     http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:19:15 GMT
+  recorded_at: Sun, 08 Oct 2017 17:12:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/title/episode.yml
+++ b/spec/vcr/title/episode.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://omdbapi.com/?episode=1&t=True%20Detective
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&episode=1&t=True%20Detective
     body:
       encoding: US-ASCII
       string: ''
@@ -19,22 +19,22 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Jun 2016 20:21:14 GMT
+      - Sun, 08 Oct 2017 17:11:48 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
-      - close
+      - keep-alive
       Set-Cookie:
-      - __cfduid=d69a319cbaea635c34ad33dda9749d8a51465590074; expires=Sat, 10-Jun-17
-        20:21:14 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      - __cfduid=d69802fbe1d0917d879f4365c6379583c1507482708; expires=Mon, 08-Oct-18
+        17:11:48 GMT; path=/; domain=.omdbapi.com; HttpOnly
       Cache-Control:
       - public, max-age=3600
       Expires:
-      - Fri, 10 Jun 2016 21:21:12 GMT
+      - Sun, 08 Oct 2017 18:11:48 GMT
       Last-Modified:
-      - Fri, 10 Jun 2016 20:21:12 GMT
+      - Sun, 08 Oct 2017 17:11:48 GMT
       Vary:
       - "*"
       X-Aspnet-Version:
@@ -46,7 +46,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Cf-Ray:
-      - 2b0f874c88f428ac-SJC
+      - 3aaab8b0475d1bd3-SEA
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -55,18 +55,21 @@ http_interactions:
         bWUiOiI1NSBtaW4iLCJHZW5yZSI6IkNyaW1lLCBEcmFtYSwgTXlzdGVyeSIs
         IkRpcmVjdG9yIjoiTi9BIiwiV3JpdGVyIjoiTmljIFBpenpvbGF0dG8iLCJB
         Y3RvcnMiOiJNYXR0aGV3IE1jQ29uYXVnaGV5LCBDb2xpbiBGYXJyZWxsLCBX
-        b29keSBIYXJyZWxzb24sIFJhY2hlbCBNY0FkYW1zIiwiUGxvdCI6IkFuIGFu
-        dGhvbG9neSBzZXJpZXMgaW4gd2hpY2ggcG9saWNlIGludmVzdGlnYXRpb25z
-        IHVuZWFydGggdGhlIHBlcnNvbmFsIGFuZCBwcm9mZXNzaW9uYWwgc2VjcmV0
-        cyBvZiB0aG9zZSBpbnZvbHZlZCwgYm90aCB3aXRoaW4gYW5kIG91dHNpZGUg
-        dGhlIGxhdy4iLCJMYW5ndWFnZSI6IkVuZ2xpc2giLCJDb3VudHJ5IjoiVVNB
-        IiwiQXdhcmRzIjoiTm9taW5hdGVkIGZvciA0IEdvbGRlbiBHbG9iZXMuIEFu
-        b3RoZXIgMjcgd2lucyAmIDUyIG5vbWluYXRpb25zLiIsIlBvc3RlciI6Imh0
-        dHA6Ly9pYS5tZWRpYS1pbWRiLmNvbS9pbWFnZXMvTS9NVjVCTVRVek5UTXdP
-        REkxT1Y1Qk1sNUJhbkJuWGtGdFpUZ3dNREl6TVRRME5URUAuX1YxX1NYMzAw
-        LmpwZyIsIk1ldGFzY29yZSI6Ik4vQSIsImltZGJSYXRpbmciOiI5LjEiLCJp
-        bWRiVm90ZXMiOiIzMTQsMjI4IiwiaW1kYklEIjoidHQyMzU2Nzc3IiwiVHlw
-        ZSI6InNlcmllcyIsIlJlc3BvbnNlIjoiVHJ1ZSJ9
+        b29keSBIYXJyZWxzb24sIFJhY2hlbCBNY0FkYW1zIiwiUGxvdCI6IlNlYXNv
+        bmFsIGFudGhvbG9neSBzZXJpZXMgaW4gd2hpY2ggcG9saWNlIGludmVzdGln
+        YXRpb25zIHVuZWFydGggdGhlIHBlcnNvbmFsIGFuZCBwcm9mZXNzaW9uYWwg
+        c2VjcmV0cyBvZiB0aG9zZSBpbnZvbHZlZCwgYm90aCB3aXRoaW4gYW5kIG91
+        dHNpZGUgdGhlIGxhdy4iLCJMYW5ndWFnZSI6IkVuZ2xpc2giLCJDb3VudHJ5
+        IjoiVVNBIiwiQXdhcmRzIjoiTm9taW5hdGVkIGZvciA0IEdvbGRlbiBHbG9i
+        ZXMuIEFub3RoZXIgMzAgd2lucyAmIDU2IG5vbWluYXRpb25zLiIsIlBvc3Rl
+        ciI6Imh0dHBzOi8vaW1hZ2VzLW5hLnNzbC1pbWFnZXMtYW1hem9uLmNvbS9p
+        bWFnZXMvTS9NVjVCTW1SbFltRTBZMlV0TkRrMllpMDBOemN6TFdFd1pURXRa
+        bUUyT1RjeVl6Y3hZbVU1WGtFeVhrRnFjR2RlUVhWeU5UTXhNamd4TXpBQC5f
+        VjFfU1gzMDAuanBnIiwiUmF0aW5ncyI6W3siU291cmNlIjoiSW50ZXJuZXQg
+        TW92aWUgRGF0YWJhc2UiLCJWYWx1ZSI6IjkuMC8xMCJ9XSwiTWV0YXNjb3Jl
+        IjoiTi9BIiwiaW1kYlJhdGluZyI6IjkuMCIsImltZGJWb3RlcyI6IjM3MCw2
+        NDciLCJpbWRiSUQiOiJ0dDIzNTY3NzciLCJUeXBlIjoic2VyaWVzIiwidG90
+        YWxTZWFzb25zIjoiMiIsIlJlc3BvbnNlIjoiVHJ1ZSJ9
     http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:21:14 GMT
+  recorded_at: Sun, 08 Oct 2017 17:11:48 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/title/nonexistent.yml
+++ b/spec/vcr/title/nonexistent.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://omdbapi.com/?t=lsdfoweirjrpwef323423dsfkip
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&t=lsdfoweirjrpwef323423dsfkip
     body:
       encoding: US-ASCII
       string: ''
@@ -19,22 +19,22 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Jun 2016 20:19:14 GMT
+      - Sun, 08 Oct 2017 17:11:48 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
       - '47'
       Connection:
-      - close
+      - keep-alive
       Set-Cookie:
-      - __cfduid=d844ff6dce7b48821bfe9fabea23c67f21465589954; expires=Sat, 10-Jun-17
-        20:19:14 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      - __cfduid=db0c28b77349b1535a6db74e4384f37621507482708; expires=Mon, 08-Oct-18
+        17:11:48 GMT; path=/; domain=.omdbapi.com; HttpOnly
       Cache-Control:
       - public, max-age=3600
       Expires:
-      - Fri, 10 Jun 2016 21:19:12 GMT
+      - Sun, 08 Oct 2017 18:11:48 GMT
       Last-Modified:
-      - Fri, 10 Jun 2016 20:19:12 GMT
+      - Sun, 08 Oct 2017 17:11:48 GMT
       Vary:
       - "*"
       X-Aspnet-Version:
@@ -46,10 +46,10 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Cf-Ray:
-      - 2b0f8460492311c5-SJC
+      - 3aaab8b0f1a429e9-SEA
     body:
       encoding: UTF-8
       string: '{"Response":"False","Error":"Movie not found!"}'
     http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:19:14 GMT
+  recorded_at: Sun, 08 Oct 2017 17:11:48 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/title/plot.yml
+++ b/spec/vcr/title/plot.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://omdbapi.com/?t=Game%20of%20Thrones
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&t=Game%20of%20Thrones
     body:
       encoding: US-ASCII
       string: ''
@@ -19,93 +19,22 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Jun 2016 20:19:13 GMT
+      - Sun, 08 Oct 2017 17:11:47 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
-      - close
+      - keep-alive
       Set-Cookie:
-      - __cfduid=d16d72d802b23a0774017b7abdfd35a031465589953; expires=Sat, 10-Jun-17
-        20:19:13 GMT; path=/; domain=.omdbapi.com; HttpOnly
-      Cache-Control:
-      - public, max-age=1768
-      Expires:
-      - Fri, 10 Jun 2016 20:48:40 GMT
-      Last-Modified:
-      - Fri, 10 Jun 2016 19:48:40 GMT
-      Vary:
-      - "*"
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Powered-By:
-      - ASP.NET
-      Access-Control-Allow-Origin:
-      - "*"
-      Server:
-      - cloudflare-nginx
-      Cf-Ray:
-      - 2b0f845c0f4041cf-SJC
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        eyJUaXRsZSI6IkdhbWUgb2YgVGhyb25lcyIsIlllYXIiOiIyMDEx4oCTIiwi
-        UmF0ZWQiOiJUVi1NQSIsIlJlbGVhc2VkIjoiMTcgQXByIDIwMTEiLCJSdW50
-        aW1lIjoiNTYgbWluIiwiR2VucmUiOiJBZHZlbnR1cmUsIERyYW1hLCBGYW50
-        YXN5IiwiRGlyZWN0b3IiOiJOL0EiLCJXcml0ZXIiOiJEYXZpZCBCZW5pb2Zm
-        LCBELkIuIFdlaXNzIiwiQWN0b3JzIjoiUGV0ZXIgRGlua2xhZ2UsIExlbmEg
-        SGVhZGV5LCBLaXQgSGFyaW5ndG9uLCBFbWlsaWEgQ2xhcmtlIiwiUGxvdCI6
-        IldoaWxlIGEgY2l2aWwgd2FyIGJyZXdzIGJldHdlZW4gc2V2ZXJhbCBub2Js
-        ZSBmYW1pbGllcyBpbiBXZXN0ZXJvcywgdGhlIGNoaWxkcmVuIG9mIHRoZSBm
-        b3JtZXIgcnVsZXJzIG9mIHRoZSBsYW5kIGF0dGVtcHQgdG8gcmlzZSB1cCB0
-        byBwb3dlci4gTWVhbndoaWxlIGEgZm9yZ290dGVuIHJhY2UsIGJlbnQgb24g
-        ZGVzdHJ1Y3Rpb24sIHBsYW5zIHRvIHJldHVybiBhZnRlciB0aG91c2FuZHMg
-        b2YgeWVhcnMgaW4gdGhlIE5vcnRoLiIsIkxhbmd1YWdlIjoiRW5nbGlzaCIs
-        IkNvdW50cnkiOiJVU0EsIFVLIiwiQXdhcmRzIjoiV29uIDEgR29sZGVuIEds
-        b2JlLiBBbm90aGVyIDE4MyB3aW5zICYgMzA1IG5vbWluYXRpb25zLiIsIlBv
-        c3RlciI6Imh0dHA6Ly9pYS5tZWRpYS1pbWRiLmNvbS9pbWFnZXMvTS9NVjVC
-        TWpNNU9UUTFNVFk1Tmw1Qk1sNUJhbkJuWGtGdFpUZ3dNak0zTnpNeE9ERUAu
-        X1YxX1NYMzAwLmpwZyIsIk1ldGFzY29yZSI6Ik4vQSIsImltZGJSYXRpbmci
-        OiI5LjUiLCJpbWRiVm90ZXMiOiI5NzMsNDAzIiwiaW1kYklEIjoidHQwOTQ0
-        OTQ3IiwiVHlwZSI6InNlcmllcyIsIlJlc3BvbnNlIjoiVHJ1ZSJ9
-    http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:19:14 GMT
-- request:
-    method: get
-    uri: http://omdbapi.com/?plot=full&t=Game%20of%20Thrones
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 10 Jun 2016 20:19:14 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - close
-      Set-Cookie:
-      - __cfduid=d5484dfdd82a18d413cbe1d327989af7d1465589954; expires=Sat, 10-Jun-17
-        20:19:14 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      - __cfduid=d07d392429286e5352ec63c7a99ee50111507482707; expires=Mon, 08-Oct-18
+        17:11:47 GMT; path=/; domain=.omdbapi.com; HttpOnly
       Cache-Control:
       - public, max-age=3600
       Expires:
-      - Fri, 10 Jun 2016 21:19:12 GMT
+      - Sun, 08 Oct 2017 18:11:47 GMT
       Last-Modified:
-      - Fri, 10 Jun 2016 20:19:12 GMT
+      - Sun, 08 Oct 2017 17:11:47 GMT
       Vary:
       - "*"
       X-Aspnet-Version:
@@ -117,33 +46,104 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Cf-Ray:
-      - 2b0f845cac212822-SJC
+      - 3aaab8a903607a1d-SEA
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJUaXRsZSI6IkdhbWUgb2YgVGhyb25lcyIsIlllYXIiOiIyMDEx4oCTIiwi
         UmF0ZWQiOiJUVi1NQSIsIlJlbGVhc2VkIjoiMTcgQXByIDIwMTEiLCJSdW50
-        aW1lIjoiNTYgbWluIiwiR2VucmUiOiJBZHZlbnR1cmUsIERyYW1hLCBGYW50
+        aW1lIjoiNTcgbWluIiwiR2VucmUiOiJBZHZlbnR1cmUsIERyYW1hLCBGYW50
         YXN5IiwiRGlyZWN0b3IiOiJOL0EiLCJXcml0ZXIiOiJEYXZpZCBCZW5pb2Zm
         LCBELkIuIFdlaXNzIiwiQWN0b3JzIjoiUGV0ZXIgRGlua2xhZ2UsIExlbmEg
-        SGVhZGV5LCBLaXQgSGFyaW5ndG9uLCBFbWlsaWEgQ2xhcmtlIiwiUGxvdCI6
-        Ik5lZCBTdGFyaywgTG9yZCBvZiBXaW50ZXJmZWxsLCBiZWNvbWVzIHRoZSBI
-        YW5kIG9mIHRoZSBLaW5nIGFmdGVyIHRoZSBmb3JtZXIgSGFuZCwgSm9uIEFy
-        cnluLCBoYXMgcGFzc2VkIGF3YXkuIEJ1dCBiZWZvcmUgTmVkIGdvZXMgdG8g
-        dGhlIGNhcGl0YWwsIEtpbmcncyBMYW5kaW5nLCBhIGxldHRlciBhcnJpdmVz
-        IGZyb20gaGlzIHdpZmUncyBzaXN0ZXIgTHlzYSwgd2hvIHdhcyB0aGUgd2lm
-        ZSBvZiBKb24gQXJyeW4uIFRoZXJlIGl0IHNheXMgdGhhdCBoZXIgaHVzYmFu
-        ZCB3YXMgbXVyZGVyZWQsIGFuZCBpdCBpcyB1cCB0byBOZWQgdG8gZmluZCBv
-        dXQgd2hhdCdzIGdvaW5nIG9uLiBCdXQgdGhhdCBpc24ndCBldmVyeXRoaW5n
-        LiBUaGUgV2hpdGUgV2Fsa2VycyBoYXZlIGJlZW4gc2VlbiwgYW5kIHRoZXkg
-        c2VlbSB0byBnbyBkb3duIHNvdXRoIiwiTGFuZ3VhZ2UiOiJFbmdsaXNoIiwi
-        Q291bnRyeSI6IlVTQSwgVUsiLCJBd2FyZHMiOiJXb24gMSBHb2xkZW4gR2xv
-        YmUuIEFub3RoZXIgMTgzIHdpbnMgJiAzMDUgbm9taW5hdGlvbnMuIiwiUG9z
-        dGVyIjoiaHR0cDovL2lhLm1lZGlhLWltZGIuY29tL2ltYWdlcy9NL01WNUJN
-        ak01T1RRMU1UWTVObDVCTWw1QmFuQm5Ya0Z0WlRnd01qTTNOek14T0RFQC5f
-        VjFfU1gzMDAuanBnIiwiTWV0YXNjb3JlIjoiTi9BIiwiaW1kYlJhdGluZyI6
-        IjkuNSIsImltZGJWb3RlcyI6Ijk3Myw0MDMiLCJpbWRiSUQiOiJ0dDA5NDQ5
-        NDciLCJUeXBlIjoic2VyaWVzIiwiUmVzcG9uc2UiOiJUcnVlIn0=
+        SGVhZGV5LCBFbWlsaWEgQ2xhcmtlLCBLaXQgSGFyaW5ndG9uIiwiUGxvdCI6
+        Ik5pbmUgbm9ibGUgZmFtaWxpZXMgZmlnaHQgZm9yIGNvbnRyb2wgb3ZlciB0
+        aGUgbXl0aGljYWwgbGFuZHMgb2YgV2VzdGVyb3MsIHdoaWxlIGEgZm9yZ290
+        dGVuIHJhY2UgcmV0dXJucyBhZnRlciBiZWluZyBkb3JtYW50IGZvciB0aG91
+        c2FuZHMgb2YgeWVhcnMuIiwiTGFuZ3VhZ2UiOiJFbmdsaXNoIiwiQ291bnRy
+        eSI6IlVTQSwgVUsiLCJBd2FyZHMiOiJXb24gMSBHb2xkZW4gR2xvYmUuIEFu
+        b3RoZXIgMjQ5IHdpbnMgJiA0MjIgbm9taW5hdGlvbnMuIiwiUG9zdGVyIjoi
+        aHR0cHM6Ly9pbWFnZXMtbmEuc3NsLWltYWdlcy1hbWF6b24uY29tL2ltYWdl
+        cy9NL01WNUJNakUzTlRRMU5EZzFNbDVCTWw1QmFuQm5Ya0Z0WlRnd056WTJO
+        REEwTWpJQC5fVjFfU1gzMDAuanBnIiwiUmF0aW5ncyI6W3siU291cmNlIjoi
+        SW50ZXJuZXQgTW92aWUgRGF0YWJhc2UiLCJWYWx1ZSI6IjkuNS8xMCJ9XSwi
+        TWV0YXNjb3JlIjoiTi9BIiwiaW1kYlJhdGluZyI6IjkuNSIsImltZGJWb3Rl
+        cyI6IjEsMjM0LDExNyIsImltZGJJRCI6InR0MDk0NDk0NyIsIlR5cGUiOiJz
+        ZXJpZXMiLCJ0b3RhbFNlYXNvbnMiOiI4IiwiUmVzcG9uc2UiOiJUcnVlIn0=
     http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:19:14 GMT
+  recorded_at: Sun, 08 Oct 2017 17:11:47 GMT
+- request:
+    method: get
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&plot=full&t=Game%20of%20Thrones
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 08 Oct 2017 17:11:47 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dc3cec81c973b38a74ab658520686bfd41507482707; expires=Mon, 08-Oct-18
+        17:11:47 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      Cache-Control:
+      - public, max-age=3600
+      Expires:
+      - Sun, 08 Oct 2017 18:11:47 GMT
+      Last-Modified:
+      - Sun, 08 Oct 2017 17:11:47 GMT
+      Vary:
+      - "*"
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare-nginx
+      Cf-Ray:
+      - 3aaab8a9d36e7985-SEA
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJUaXRsZSI6IkdhbWUgb2YgVGhyb25lcyIsIlllYXIiOiIyMDEx4oCTIiwi
+        UmF0ZWQiOiJUVi1NQSIsIlJlbGVhc2VkIjoiMTcgQXByIDIwMTEiLCJSdW50
+        aW1lIjoiNTcgbWluIiwiR2VucmUiOiJBZHZlbnR1cmUsIERyYW1hLCBGYW50
+        YXN5IiwiRGlyZWN0b3IiOiJOL0EiLCJXcml0ZXIiOiJEYXZpZCBCZW5pb2Zm
+        LCBELkIuIFdlaXNzIiwiQWN0b3JzIjoiUGV0ZXIgRGlua2xhZ2UsIExlbmEg
+        SGVhZGV5LCBFbWlsaWEgQ2xhcmtlLCBLaXQgSGFyaW5ndG9uIiwiUGxvdCI6
+        IkluIHRoZSBteXRoaWNhbCBjb250aW5lbnQgb2YgV2VzdGVyb3MsIHNldmVy
+        YWwgcG93ZXJmdWwgZmFtaWxpZXMgZmlnaHQgZm9yIGNvbnRyb2wgb2YgdGhl
+        IFNldmVuIEtpbmdkb21zLiBBcyBjb25mbGljdCBlcnVwdHMgaW4gdGhlIGtp
+        bmdkb21zIG9mIG1lbiwgYW4gYW5jaWVudCBlbmVteSByaXNlcyBvbmNlIGFn
+        YWluIHRvIHRocmVhdGVuIHRoZW0gYWxsLiBNZWFud2hpbGUsIHRoZSBsYXN0
+        IGhlaXJzIG9mIGEgcmVjZW50bHkgdXN1cnBlZCBkeW5hc3R5IHBsb3QgdG8g
+        dGFrZSBiYWNrIHRoZWlyIGhvbWVsYW5kIGZyb20gYWNyb3NzIHRoZSBOYXJy
+        b3cgU2VhLiIsIkxhbmd1YWdlIjoiRW5nbGlzaCIsIkNvdW50cnkiOiJVU0Es
+        IFVLIiwiQXdhcmRzIjoiV29uIDEgR29sZGVuIEdsb2JlLiBBbm90aGVyIDI0
+        OSB3aW5zICYgNDIyIG5vbWluYXRpb25zLiIsIlBvc3RlciI6Imh0dHBzOi8v
+        aW1hZ2VzLW5hLnNzbC1pbWFnZXMtYW1hem9uLmNvbS9pbWFnZXMvTS9NVjVC
+        TWpFM05UUTFORGcxTWw1Qk1sNUJhbkJuWGtGdFpUZ3dOelkyTkRBME1qSUAu
+        X1YxX1NYMzAwLmpwZyIsIlJhdGluZ3MiOlt7IlNvdXJjZSI6IkludGVybmV0
+        IE1vdmllIERhdGFiYXNlIiwiVmFsdWUiOiI5LjUvMTAifV0sIk1ldGFzY29y
+        ZSI6Ik4vQSIsImltZGJSYXRpbmciOiI5LjUiLCJpbWRiVm90ZXMiOiIxLDIz
+        NCwxMTciLCJpbWRiSUQiOiJ0dDA5NDQ5NDciLCJUeXBlIjoic2VyaWVzIiwi
+        dG90YWxTZWFzb25zIjoiOCIsIlJlc3BvbnNlIjoiVHJ1ZSJ9
+    http_version: 
+  recorded_at: Sun, 08 Oct 2017 17:11:47 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/title/season.yml
+++ b/spec/vcr/title/season.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://omdbapi.com/?season=1&t=True%20Detective
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&season=1&t=True%20Detective
     body:
       encoding: US-ASCII
       string: ''
@@ -19,22 +19,22 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Jun 2016 20:19:14 GMT
+      - Sun, 08 Oct 2017 17:11:48 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
-      - close
+      - keep-alive
       Set-Cookie:
-      - __cfduid=d8ec542a806a0e8fa67937b6725853bee1465589954; expires=Sat, 10-Jun-17
-        20:19:14 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      - __cfduid=dde61cab0be382a4abc0be038f51aed1f1507482708; expires=Mon, 08-Oct-18
+        17:11:48 GMT; path=/; domain=.omdbapi.com; HttpOnly
       Cache-Control:
-      - public, max-age=3599
+      - public, max-age=3600
       Expires:
-      - Fri, 10 Jun 2016 21:19:12 GMT
+      - Sun, 08 Oct 2017 18:11:48 GMT
       Last-Modified:
-      - Fri, 10 Jun 2016 20:19:12 GMT
+      - Sun, 08 Oct 2017 17:11:48 GMT
       Vary:
       - "*"
       X-Aspnet-Version:
@@ -46,18 +46,18 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Cf-Ray:
-      - 2b0f845e75cb284c-SJC
+      - 3aaab8af758f79d3-SEA
     body:
       encoding: ASCII-8BIT
-      string: '{"Title":"True Detective","Season":"1","Episodes":[{"Title":"The Long
-        Bright Dark","Released":"2014-01-12","Episode":"1","imdbRating":"9.0","imdbID":"tt2657398"},{"Title":"Seeing
+      string: '{"Title":"True Detective","Season":"1","totalSeasons":"2","Episodes":[{"Title":"The
+        Long Bright Dark","Released":"2014-01-12","Episode":"1","imdbRating":"9.0","imdbID":"tt2657398"},{"Title":"Seeing
         Things","Released":"2014-01-19","Episode":"2","imdbRating":"8.9","imdbID":"tt2704380"},{"Title":"The
         Locked Room","Released":"2014-01-26","Episode":"3","imdbRating":"9.2","imdbID":"tt2790184"},{"Title":"Who
         Goes There","Released":"2014-02-09","Episode":"4","imdbRating":"9.7","imdbID":"tt2790174"},{"Title":"The
         Secret Fate of All Life","Released":"2014-02-16","Episode":"5","imdbRating":"9.6","imdbID":"tt2790196"},{"Title":"Haunted
         Houses","Released":"2014-02-23","Episode":"6","imdbRating":"9.2","imdbID":"tt2790238"},{"Title":"After
         You''ve Gone","Released":"2014-03-02","Episode":"7","imdbRating":"9.2","imdbID":"tt2790240"},{"Title":"Form
-        and Void","Released":"2014-03-09","Episode":"8","imdbRating":"9.5","imdbID":"tt2790254"}],"Response":"True"}'
+        and Void","Released":"2014-03-09","Episode":"8","imdbRating":"9.6","imdbID":"tt2790254"}],"Response":"True"}'
     http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:19:14 GMT
+  recorded_at: Sun, 08 Oct 2017 17:11:48 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/title/season_and_episode.yml
+++ b/spec/vcr/title/season_and_episode.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://omdbapi.com/?episode=1&season=1&t=True%20Detective
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&episode=1&season=1&t=True%20Detective
     body:
       encoding: US-ASCII
       string: ''
@@ -19,22 +19,22 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Jun 2016 20:21:28 GMT
+      - Sun, 08 Oct 2017 17:11:48 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
-      - close
+      - keep-alive
       Set-Cookie:
-      - __cfduid=d9f8126cd4b7aa3390b802358a39df7801465590088; expires=Sat, 10-Jun-17
-        20:21:28 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      - __cfduid=de95e25918407fab69817003a4db786ea1507482707; expires=Mon, 08-Oct-18
+        17:11:47 GMT; path=/; domain=.omdbapi.com; HttpOnly
       Cache-Control:
       - public, max-age=3600
       Expires:
-      - Fri, 10 Jun 2016 21:21:26 GMT
+      - Sun, 08 Oct 2017 18:11:47 GMT
       Last-Modified:
-      - Fri, 10 Jun 2016 20:21:26 GMT
+      - Sun, 08 Oct 2017 17:11:47 GMT
       Vary:
       - "*"
       X-Aspnet-Version:
@@ -46,16 +46,17 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Cf-Ray:
-      - 2b0f87a52e8b287c-SJC
+      - 3aaab8abe1cc2a0d-SEA
     body:
       encoding: ASCII-8BIT
       string: '{"Title":"The Long Bright Dark","Year":"2014","Rated":"TV-MA","Released":"12
         Jan 2014","Season":"1","Episode":"1","Runtime":"58 min","Genre":"Crime, Drama,
-        Mystery","Director":"Cary Joji Fukunaga","Writer":"Nic Pizzolatto (created
-        by), Nic Pizzolatto","Actors":"Matthew McConaughey, Woody Harrelson, Michelle
-        Monaghan, Michael Potts","Plot":"In 2012, former detective partners, Rust
-        Cohle and Martin Hart recap one of their very first cases together involving
-        a serial killer, back in 1995.","Language":"English","Country":"USA","Awards":"N/A","Poster":"http://ia.media-imdb.com/images/M/MV5BMTY5NjA2MjEyN15BMl5BanBnXkFtZTgwNzU2MjQ4MDE@._V1_SX300.jpg","Metascore":"N/A","imdbRating":"9.0","imdbVotes":"10914","imdbID":"tt2657398","seriesID":"tt2356777","Type":"episode","Response":"True"}'
+        Mystery","Director":"Cary Fukunaga","Writer":"Nic Pizzolatto (created by),
+        Nic Pizzolatto","Actors":"Matthew McConaughey, Woody Harrelson, Michelle Monaghan,
+        Michael Potts","Plot":"In 2012, former detective partners Rust Cohle and Martin
+        Hart recap one of their very first cases together involving a serial killer,
+        back in 1995.","Language":"English","Country":"USA","Awards":"N/A","Poster":"https://images-na.ssl-images-amazon.com/images/M/MV5BMjkxMzMxNDQxNF5BMl5BanBnXkFtZTgwNDE2NzM2MjE@._V1_SX300.jpg","Ratings":[{"Source":"Internet
+        Movie Database","Value":"9.0/10"}],"Metascore":"N/A","imdbRating":"9.0","imdbVotes":"12591","imdbID":"tt2657398","seriesID":"tt2356777","Type":"episode","Response":"True"}'
     http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:21:28 GMT
+  recorded_at: Sun, 08 Oct 2017 17:11:48 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/title/tomatoes.yml
+++ b/spec/vcr/title/tomatoes.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://omdbapi.com/?t=inception&tomatoes=true
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&t=inception&tomatoes=true
     body:
       encoding: US-ASCII
       string: ''
@@ -19,22 +19,22 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Jun 2016 20:19:14 GMT
+      - Sun, 08 Oct 2017 17:12:48 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
-      - close
+      - keep-alive
       Set-Cookie:
-      - __cfduid=d8a2312fd7c55b83c70b9826c5256aa1c1465589954; expires=Sat, 10-Jun-17
-        20:19:14 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      - __cfduid=dfad9e4d068e1ae59f3c890fad6e0b0da1507482768; expires=Mon, 08-Oct-18
+        17:12:48 GMT; path=/; domain=.omdbapi.com; HttpOnly
       Cache-Control:
-      - public, max-age=3454
+      - public, max-age=3508
       Expires:
-      - Fri, 10 Jun 2016 21:16:47 GMT
+      - Sun, 08 Oct 2017 18:11:16 GMT
       Last-Modified:
-      - Fri, 10 Jun 2016 20:16:47 GMT
+      - Sun, 08 Oct 2017 17:11:16 GMT
       Vary:
       - "*"
       X-Aspnet-Version:
@@ -46,19 +46,18 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Cf-Ray:
-      - 2b0f846147da1e5f-SJC
+      - 3aaaba28a4302a31-SEA
     body:
       encoding: ASCII-8BIT
       string: '{"Title":"Inception","Year":"2010","Rated":"PG-13","Released":"16 Jul
-        2010","Runtime":"148 min","Genre":"Action, Mystery, Sci-Fi","Director":"Christopher
+        2010","Runtime":"148 min","Genre":"Action, Adventure, Sci-Fi","Director":"Christopher
         Nolan","Writer":"Christopher Nolan","Actors":"Leonardo DiCaprio, Joseph Gordon-Levitt,
         Ellen Page, Tom Hardy","Plot":"A thief, who steals corporate secrets through
         use of dream-sharing technology, is given the inverse task of planting an
-        idea into the mind of a CEO.","Language":"English, French, Japanese","Country":"USA,
-        UK","Awards":"Won 4 Oscars. Another 139 wins & 192 nominations.","Poster":"http://ia.media-imdb.com/images/M/MV5BMjAxMzY3NjcxNF5BMl5BanBnXkFtZTcwNTI5OTM0Mw@@._V1_SX300.jpg","Metascore":"74","imdbRating":"8.8","imdbVotes":"1,434,451","imdbID":"tt1375666","Type":"movie","tomatoMeter":"86","tomatoImage":"certified","tomatoRating":"8.1","tomatoReviews":"326","tomatoFresh":"282","tomatoRotten":"44","tomatoConsensus":"Smart,
-        innovative, and thrilling, Inception is that rare summer blockbuster that
-        succeeds viscerally as well as intellectually.","tomatoUserMeter":"91","tomatoUserRating":"4.2","tomatoUserReviews":"564261","tomatoURL":"http://www.rottentomatoes.com/m/inception/","DVD":"07
-        Dec 2010","BoxOffice":"$292.6M","Production":"Warner Bros. Pictures","Website":"http://inceptionmovie.warnerbros.com/","Response":"True"}'
+        idea into the mind of a CEO.","Language":"English, Japanese, French","Country":"USA,
+        UK","Awards":"Won 4 Oscars. Another 152 wins & 204 nominations.","Poster":"https://images-na.ssl-images-amazon.com/images/M/MV5BMjAxMzY3NjcxNF5BMl5BanBnXkFtZTcwNTI5OTM0Mw@@._V1_SX300.jpg","Ratings":[{"Source":"Internet
+        Movie Database","Value":"8.8/10"},{"Source":"Rotten Tomatoes","Value":"86%"},{"Source":"Metacritic","Value":"74/100"}],"Metascore":"74","imdbRating":"8.8","imdbVotes":"1,626,815","imdbID":"tt1375666","Type":"movie","tomatoMeter":"N/A","tomatoImage":"N/A","tomatoRating":"N/A","tomatoReviews":"N/A","tomatoFresh":"N/A","tomatoRotten":"N/A","tomatoConsensus":"N/A","tomatoUserMeter":"N/A","tomatoUserRating":"N/A","tomatoUserReviews":"N/A","tomatoURL":"http://www.rottentomatoes.com/m/inception/","DVD":"07
+        Dec 2010","BoxOffice":"$292,568,851","Production":"Warner Bros. Pictures","Website":"http://inceptionmovie.warnerbros.com/","Response":"True"}'
     http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:19:14 GMT
+  recorded_at: Sun, 08 Oct 2017 17:12:48 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/title/valid.yml
+++ b/spec/vcr/title/valid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://omdbapi.com/?t=Star%20Wars
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&t=Star%20Wars
     body:
       encoding: US-ASCII
       string: ''
@@ -19,22 +19,22 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Jun 2016 20:19:13 GMT
+      - Sun, 08 Oct 2017 17:11:47 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
-      - close
+      - keep-alive
       Set-Cookie:
-      - __cfduid=dff811992f618e7e9c901f0100511a0181465589953; expires=Sat, 10-Jun-17
-        20:19:13 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      - __cfduid=d8c8694689a08d8b74e7a2f72648a136d1507482707; expires=Mon, 08-Oct-18
+        17:11:47 GMT; path=/; domain=.omdbapi.com; HttpOnly
       Cache-Control:
-      - public, max-age=959
+      - public, max-age=3507
       Expires:
-      - Fri, 10 Jun 2016 20:35:10 GMT
+      - Sun, 08 Oct 2017 18:10:14 GMT
       Last-Modified:
-      - Fri, 10 Jun 2016 19:35:10 GMT
+      - Sun, 08 Oct 2017 17:10:14 GMT
       Vary:
       - "*"
       X-Aspnet-Version:
@@ -46,12 +46,19 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Cf-Ray:
-      - 2b0f8459291e1e83-SJC
+      - 3aaab8a6e5c91baf-SEA
     body:
       encoding: ASCII-8BIT
-      string: '{"Title":"Star Wars","Year":"1983","Rated":"N/A","Released":"01 May
-        1983","Runtime":"N/A","Genre":"Action, Adventure, Sci-Fi","Director":"N/A","Writer":"N/A","Actors":"Harrison
-        Ford, Alec Guinness, Mark Hamill, James Earl Jones","Plot":"N/A","Language":"English","Country":"USA","Awards":"N/A","Poster":"N/A","Metascore":"N/A","imdbRating":"7.9","imdbVotes":"344","imdbID":"tt0251413","Type":"game","Response":"True"}'
+      string: '{"Title":"Star Wars: Episode IV - A New Hope","Year":"1977","Rated":"PG","Released":"25
+        May 1977","Runtime":"121 min","Genre":"Action, Adventure, Fantasy","Director":"George
+        Lucas","Writer":"George Lucas","Actors":"Mark Hamill, Harrison Ford, Carrie
+        Fisher, Peter Cushing","Plot":"Luke Skywalker joins forces with a Jedi Knight,
+        a cocky pilot, a Wookiee, and two droids to save the galaxy from the Empire''s
+        world-destroying battle-station, while also attempting to rescue Princess
+        Leia from the evil Darth Vader.","Language":"English","Country":"USA","Awards":"Won
+        6 Oscars. Another 50 wins & 28 nominations.","Poster":"https://images-na.ssl-images-amazon.com/images/M/MV5BYTUwNTdiMzMtNThmNS00ODUzLThlMDMtMTM5Y2JkNWJjOGQ2XkEyXkFqcGdeQXVyNzQ1ODk3MTQ@._V1_SX300.jpg","Ratings":[{"Source":"Internet
+        Movie Database","Value":"8.7/10"},{"Source":"Rotten Tomatoes","Value":"93%"},{"Source":"Metacritic","Value":"92/100"}],"Metascore":"92","imdbRating":"8.7","imdbVotes":"999,345","imdbID":"tt0076759","Type":"movie","DVD":"21
+        Sep 2004","BoxOffice":"N/A","Production":"20th Century Fox","Website":"http://www.starwars.com/episode-iv/","Response":"True"}'
     http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:19:13 GMT
+  recorded_at: Sun, 08 Oct 2017 17:11:47 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/title/year.yml
+++ b/spec/vcr/title/year.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://omdbapi.com/?t=True%20Grit
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&t=True%20Grit
     body:
       encoding: US-ASCII
       string: ''
@@ -19,22 +19,22 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Jun 2016 20:19:13 GMT
+      - Sun, 08 Oct 2017 17:11:47 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
-      - close
+      - keep-alive
       Set-Cookie:
-      - __cfduid=d56e07752df92344fb6b7880f5f4ba48e1465589953; expires=Sat, 10-Jun-17
-        20:19:13 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      - __cfduid=d7d90d50e13cf7d915c793cf61490c4fa1507482707; expires=Mon, 08-Oct-18
+        17:11:47 GMT; path=/; domain=.omdbapi.com; HttpOnly
       Cache-Control:
       - public, max-age=3600
       Expires:
-      - Fri, 10 Jun 2016 21:19:11 GMT
+      - Sun, 08 Oct 2017 18:11:47 GMT
       Last-Modified:
-      - Fri, 10 Jun 2016 20:19:11 GMT
+      - Sun, 08 Oct 2017 17:11:47 GMT
       Vary:
       - "*"
       X-Aspnet-Version:
@@ -46,21 +46,23 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Cf-Ray:
-      - 2b0f8459bdc01edd-SJC
+      - 3aaab8a7a1a579d3-SEA
     body:
       encoding: ASCII-8BIT
       string: '{"Title":"True Grit","Year":"2010","Rated":"PG-13","Released":"22 Dec
         2010","Runtime":"110 min","Genre":"Adventure, Drama, Western","Director":"Ethan
         Coen, Joel Coen","Writer":"Joel Coen (screenplay), Ethan Coen (screenplay),
         Charles Portis (novel)","Actors":"Jeff Bridges, Hailee Steinfeld, Matt Damon,
-        Josh Brolin","Plot":"A tough U.S. Marshal helps a stubborn teenager track
-        down her father''s murderer.","Language":"English","Country":"USA","Awards":"Nominated
-        for 10 Oscars. Another 37 wins & 148 nominations.","Poster":"http://ia.media-imdb.com/images/M/MV5BMjIxNjAzODQ0N15BMl5BanBnXkFtZTcwODY2MjMyNA@@._V1_SX300.jpg","Metascore":"80","imdbRating":"7.7","imdbVotes":"237,630","imdbID":"tt1403865","Type":"movie","Response":"True"}'
+        Josh Brolin","Plot":"A stubborn teenager enlists the help of a tough U.S.
+        Marshal to track down her father''s murderer.","Language":"English","Country":"USA","Awards":"Nominated
+        for 10 Oscars. Another 37 wins & 153 nominations.","Poster":"https://images-na.ssl-images-amazon.com/images/M/MV5BMjIxNjAzODQ0N15BMl5BanBnXkFtZTcwODY2MjMyNA@@._V1_SX300.jpg","Ratings":[{"Source":"Internet
+        Movie Database","Value":"7.6/10"},{"Source":"Rotten Tomatoes","Value":"95%"},{"Source":"Metacritic","Value":"80/100"}],"Metascore":"80","imdbRating":"7.6","imdbVotes":"259,496","imdbID":"tt1403865","Type":"movie","DVD":"07
+        Jun 2011","BoxOffice":"$171,031,347","Production":"Paramount Pictures","Website":"http://www.truegritmovie.com/","Response":"True"}'
     http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:19:13 GMT
+  recorded_at: Sun, 08 Oct 2017 17:11:47 GMT
 - request:
     method: get
-    uri: http://omdbapi.com/?t=True%20Grit&y=1969
+    uri: http://omdbapi.com/?apikey=<OMDB_API_KEY>&t=True%20Grit&y=1969
     body:
       encoding: US-ASCII
       string: ''
@@ -77,22 +79,22 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Jun 2016 20:19:13 GMT
+      - Sun, 08 Oct 2017 17:11:47 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
-      - close
+      - keep-alive
       Set-Cookie:
-      - __cfduid=d16d72d802b23a0774017b7abdfd35a031465589953; expires=Sat, 10-Jun-17
-        20:19:13 GMT; path=/; domain=.omdbapi.com; HttpOnly
+      - __cfduid=de95e25918407fab69817003a4db786ea1507482707; expires=Mon, 08-Oct-18
+        17:11:47 GMT; path=/; domain=.omdbapi.com; HttpOnly
       Cache-Control:
       - public, max-age=3600
       Expires:
-      - Fri, 10 Jun 2016 21:19:11 GMT
+      - Sun, 08 Oct 2017 18:11:47 GMT
       Last-Modified:
-      - Fri, 10 Jun 2016 20:19:11 GMT
+      - Sun, 08 Oct 2017 17:11:47 GMT
       Vary:
       - "*"
       X-Aspnet-Version:
@@ -104,16 +106,18 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Cf-Ray:
-      - 2b0f845ab4c941cf-SJC
+      - 3aaab8a857fa2a0d-SEA
     body:
       encoding: ASCII-8BIT
-      string: '{"Title":"True Grit","Year":"1969","Rated":"M","Released":"11 Jun 1969","Runtime":"128
-        min","Genre":"Adventure, Western, Drama","Director":"Henry Hathaway","Writer":"Charles
+      string: '{"Title":"True Grit","Year":"1969","Rated":"G","Released":"21 Jun 1969","Runtime":"128
+        min","Genre":"Adventure, Drama, Western","Director":"Henry Hathaway","Writer":"Charles
         Portis (novel), Marguerite Roberts (screenplay)","Actors":"John Wayne, Glen
         Campbell, Kim Darby, Jeremy Slate","Plot":"A drunken, hard-nosed U.S. Marshal
         and a Texas Ranger help a stubborn teenager track down her father''s murderer
         in Indian territory.","Language":"English","Country":"USA","Awards":"Won 1
-        Oscar. Another 5 wins & 7 nominations.","Poster":"http://ia.media-imdb.com/images/M/MV5BMTYwNTE3NDYzOV5BMl5BanBnXkFtZTcwNTU5MzY0MQ@@._V1_SX300.jpg","Metascore":"N/A","imdbRating":"7.4","imdbVotes":"32,624","imdbID":"tt0065126","Type":"movie","Response":"True"}'
+        Oscar. Another 5 wins & 7 nominations.","Poster":"https://images-na.ssl-images-amazon.com/images/M/MV5BMjEwNzRlMzUtODIwMS00N2IwLWE1ZTgtODYzNWY0MGJhODY3XkEyXkFqcGdeQXVyMjI4MjA5MzA@._V1_SX300.jpg","Ratings":[{"Source":"Internet
+        Movie Database","Value":"7.4/10"},{"Source":"Rotten Tomatoes","Value":"90%"}],"Metascore":"N/A","imdbRating":"7.4","imdbVotes":"35,721","imdbID":"tt0065126","Type":"movie","DVD":"21
+        Mar 2000","BoxOffice":"N/A","Production":"Paramount Home Video","Website":"N/A","Response":"True"}'
     http_version: 
-  recorded_at: Fri, 10 Jun 2016 20:19:13 GMT
+  recorded_at: Sun, 08 Oct 2017 17:11:47 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Back in May 2017 OMDB started requiring an api key to help cover
bandwidth costs. This patch adds support for the api key.  The key can
be set inline in code or via an ENV var (see README for details). Specs
have bene updated to use API key as well.